### PR TITLE
feat: 为实验接口响应添加课程名称字段

### DIFF
--- a/src/main/java/com/example/demo/controller/teacher/TeacherExperimentController.java
+++ b/src/main/java/com/example/demo/controller/teacher/TeacherExperimentController.java
@@ -8,6 +8,7 @@ import com.example.demo.pojo.request.teacher.CreateExperimentRequest;
 import com.example.demo.pojo.request.teacher.UpdateExperimentRequest;
 import com.example.demo.pojo.response.ApiResponse;
 import com.example.demo.pojo.response.ExperimentResponse;
+import com.example.demo.service.CourseService;
 import com.example.demo.service.ExperimentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 public class TeacherExperimentController {
 
     private final ExperimentService experimentService;
+    private final CourseService courseService;
 
     /**
      * 创建实验
@@ -164,6 +166,14 @@ public class TeacherExperimentController {
             ExperimentResponse response = new ExperimentResponse();
             BeanUtils.copyProperties(experiment, response);
 
+            // 设置课程名称
+            if (experiment.getCourseId() != null) {
+                var course = courseService.getByCourseCode(experiment.getCourseId());
+                if (course != null) {
+                    response.setCourseName(course.getCourseName());
+                }
+            }
+
             return ApiResponse.success(response, "查询成功");
         } catch (Exception e) {
             log.error("查询实验详情失败", e);
@@ -187,9 +197,21 @@ public class TeacherExperimentController {
             queryWrapper.orderByDesc("created_time");
 
             List<Experiment> experiments = experimentService.list(queryWrapper);
+
+            // 只查询一次课程信息
+            String courseName = null;
+            if (!experiments.isEmpty() && experiments.get(0).getCourseId() != null) {
+                var course = courseService.getByCourseCode(experiments.get(0).getCourseId());
+                if (course != null) {
+                    courseName = course.getCourseName();
+                }
+            }
+
+            String finalCourseName = courseName;
             List<ExperimentResponse> responses = experiments.stream().map(experiment -> {
                 ExperimentResponse response = new ExperimentResponse();
                 BeanUtils.copyProperties(experiment, response);
+                response.setCourseName(finalCourseName);
                 return response;
             }).collect(Collectors.toList());
 
@@ -214,9 +236,29 @@ public class TeacherExperimentController {
             queryWrapper.orderByDesc("created_time");
 
             List<Experiment> experiments = experimentService.list(queryWrapper);
+
+            // 收集所有不同的 courseId
+            var distinctCourseIds = experiments.stream()
+                    .map(Experiment::getCourseId)
+                    .filter(id -> id != null)
+                    .distinct()
+                    .collect(Collectors.toList());
+
+            // 批量查询所有课程信息
+            var courseMap = new java.util.HashMap<String, String>();
+            if (!distinctCourseIds.isEmpty()) {
+                QueryWrapper<com.example.demo.pojo.entity.Course> courseQuery = new QueryWrapper<>();
+                courseQuery.in("course_id", distinctCourseIds);
+                List<com.example.demo.pojo.entity.Course> courses = courseService.list(courseQuery);
+                courses.forEach(course -> courseMap.put(course.getCourseId(), course.getCourseName()));
+            }
+
+            // 构建响应，使用 Map 避免重复查询
+            java.util.Map<String, String> finalCourseMap = courseMap;
             List<ExperimentResponse> responses = experiments.stream().map(experiment -> {
                 ExperimentResponse response = new ExperimentResponse();
                 BeanUtils.copyProperties(experiment, response);
+                response.setCourseName(finalCourseMap.get(experiment.getCourseId()));
                 return response;
             }).collect(Collectors.toList());
 

--- a/src/main/java/com/example/demo/pojo/response/ExperimentResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/ExperimentResponse.java
@@ -21,6 +21,11 @@ public class ExperimentResponse {
     private String courseId;
 
     /**
+     * 课程名称
+     */
+    private String courseName;
+
+    /**
      * 实验名称
      */
     private String experimentName;


### PR DESCRIPTION
- 在 ExperimentResponse 中添加 courseName 字段
- 在 TeacherExperimentController 中注入 CourseService 依赖
- 优化查询性能，避免 N+1 查询问题：
  * getExperimentsByCourseId: 只查询一次课程信息
  * getAllExperiments: 批量查询课程信息并使用 Map 缓存
- 所有实验查询接口现在都返回课程名称