### PR TITLE
Feat/issue4 remark refactor save

### DIFF
--- a/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
@@ -1,0 +1,32 @@
+package com.example.demo.pojo.dto.remark;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * 填空类型 remark DTO
+ * 用于序列化/反序列化 data_collection.remark 中的填空类型 JSON
+ *
+ * JSON 格式：
+ * {"fillBlanks":{"field":"value"},"fieldTolerances":{"field":0.1}}
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FillBlankRemarkDTO {
+
+    /** 填空数据（字段名 -> 答案） */
+    private Map<String, String> fillBlanks;
+
+    /** 字段级误差映射（字段名 -> 误差百分比） */
+    private Map<String, Double> fieldTolerances;
+}

--- a/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
@@ -1,0 +1,43 @@
+package com.example.demo.pojo.dto.remark;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 表格类型 remark DTO
+ * 用于序列化/反序列化 data_collection.remark 中的表格类型 JSON
+ *
+ * JSON 格式：
+ * {"tableRowHeaders":["A"],"tableColumnHeaders":["1"],"tableCellAnswers":{"A1":"value"},
+ *  "cellTolerances":{"A1":0.1},"columnTolerances":{"A":0.2}}
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TableRemarkDTO {
+
+    /** 表格行表头 */
+    private List<String> tableRowHeaders;
+
+    /** 表格列表头 */
+    private List<String> tableColumnHeaders;
+
+    /** 表格单元格答案（坐标 -> 答案） */
+    private Map<String, String> tableCellAnswers;
+
+    /** 单元格级误差映射（坐标 -> 误差百分比） */
+    private Map<String, Double> cellTolerances;
+
+    /** 列级误差映射（列名 -> 误差百分比） */
+    private Map<String, Double> columnTolerances;
+}

--- a/src/main/java/com/example/demo/pojo/entity/ClassExperiment.java
+++ b/src/main/java/com/example/demo/pojo/entity/ClassExperiment.java
@@ -5,8 +5,6 @@ import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import com.tangzc.autotable.annotation.AutoTable;
-import com.tangzc.autotable.annotation.TableIndex;
-import com.tangzc.autotable.annotation.enums.IndexTypeEnum;
 import com.tangzc.mpe.autotable.annotation.Column;
 import com.tangzc.mpe.autotable.annotation.Table;
 import lombok.Data;
@@ -22,7 +20,6 @@ import java.util.List;
 @AutoTable
 @Table(value = "classes_experiment", comment = "班级实验表 - 记录班级参加的实验（即课次）")
 @TableName("classes_experiment")
-@TableIndex(name = "courseId_experimentId",fields = {"courseId","experimentId"},type = IndexTypeEnum.UNIQUE)
 public class ClassExperiment {
 
     /** 主键ID */

--- a/src/main/java/com/example/demo/pojo/response/BaseDataCollectionDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/BaseDataCollectionDetailResponse.java
@@ -1,0 +1,41 @@
+package com.example.demo.pojo.response;
+
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
+import lombok.Data;
+
+/**
+ * 数据收集详情基础响应
+ */
+@Data
+public class BaseDataCollectionDetailResponse {
+    /**
+     * 数据收集ID
+     */
+    private Long id;
+
+    /**
+     * 数据收集类型（1-关键数据，2-表格数据，3-文件）
+     */
+    private Integer type;
+
+    /**
+     * 填空类型数据描述（type=1时返回）
+     */
+    private FillBlankRemarkDTO fillBlankRemark;
+
+    /**
+     * 表格类型数据描述（type=2时返回）
+     */
+    private TableRemarkDTO tableRemark;
+
+    /**
+     * 是否需要提交照片
+     */
+    private Boolean needPhoto;
+
+    /**
+     * 是否需要提交文档
+     */
+    private Boolean needDoc;
+}

--- a/src/main/java/com/example/demo/pojo/response/BaseSubmittedDataCollectionDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/BaseSubmittedDataCollectionDetailResponse.java
@@ -1,0 +1,91 @@
+package com.example.demo.pojo.response;
+
+import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
+import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+/**
+ * 带作答结果的数据收集详情基础响应
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class BaseSubmittedDataCollectionDetailResponse extends BaseDataCollectionDetailResponse {
+    /**
+     * 填空答案列表
+     */
+    private List<FillBlankAnswer> fillBlankAnswers;
+
+    /**
+     * 表格答案列表
+     */
+    private List<TableCellAnswer> tableCellAnswers;
+
+    /**
+     * 提交的照片文件列表
+     */
+    private List<AttachmentInfo> photos;
+
+    /**
+     * 提交的文档文件列表
+     */
+    private List<AttachmentInfo> documents;
+
+    /**
+     * 正确答案
+     */
+    private String correctAnswer;
+
+    /**
+     * 误差范围（用于数值类答案的判分）
+     */
+    private Double tolerance;
+
+    /**
+     * 附件信息
+     */
+    @Data
+    public static class AttachmentInfo {
+        /**
+         * 附件ID
+         */
+        private Long id;
+
+        /**
+         * 文件类型（1-照片，2-文档）
+         */
+        private Integer fileType;
+
+        /**
+         * 文件格式
+         */
+        private String fileFormat;
+
+        /**
+         * 原始文件名
+         */
+        private String originalFileName;
+
+        /**
+         * 文件大小（字节）
+         */
+        private Long fileSize;
+
+        /**
+         * 文件备注
+         */
+        private String remark;
+
+        /**
+         * 创建时间
+         */
+        private java.time.LocalDateTime createTime;
+
+        /**
+         * 文件下载密钥
+         */
+        private String downloadKey;
+    }
+}

--- a/src/main/java/com/example/demo/pojo/response/DataCollectionProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/DataCollectionProcedureDetailResponse.java
@@ -1,6 +1,7 @@
 package com.example.demo.pojo.response;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * 数据收集步骤详情响应（未提交）
@@ -43,30 +44,7 @@ public class DataCollectionProcedureDetailResponse {
      * 数据收集详情
      */
     @Data
-    public static class DataCollectionDetail {
-        /**
-         * 数据收集ID
-         */
-        private Long id;
-
-        /**
-         * 数据收集类型（1-关键数据，2-表格数据，3-文件）
-         */
-        private Integer type;
-
-        /**
-         * 数据描述
-         */
-        private String remark;
-
-        /**
-         * 是否需要提交照片
-         */
-        private Boolean needPhoto;
-
-        /**
-         * 是否需要提交文档
-         */
-        private Boolean needDoc;
+    @EqualsAndHashCode(callSuper = true)
+    public static class DataCollectionDetail extends BaseDataCollectionDetailResponse {
     }
 }

--- a/src/main/java/com/example/demo/pojo/response/DataCollectionProcedureSubmittedResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/DataCollectionProcedureSubmittedResponse.java
@@ -1,12 +1,10 @@
 package com.example.demo.pojo.response;
 
-import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
-import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 数据收集步骤详情响应（已提交）
@@ -87,107 +85,15 @@ public class DataCollectionProcedureSubmittedResponse {
      * 数据收集详情
      */
     @Data
-    public static class DataCollectionDetail {
-        /**
-         * 数据收集ID
-         */
-        private Long id;
-
-        /**
-         * 数据收集类型（1-关键数据，2-表格数据，3-文件）
-         */
-        private Integer type;
-
-        /**
-         * 数据描述
-         */
-        private String remark;
-
-        /**
-         * 是否需要提交照片
-         */
-        private Boolean needPhoto;
-
-        /**
-         * 是否需要提交文档
-         */
-        private Boolean needDoc;
-
-        /**
-         * 填空答案列表
-         */
-        private List<FillBlankAnswer> fillBlankAnswers;
-
-        /**
-         * 表格答案列表
-         */
-        private List<TableCellAnswer> tableCellAnswers;
-
-        /**
-         * 提交的照片文件列表
-         */
-        private List<AttachmentInfo> photos;
-
-        /**
-         * 提交的文档文件列表
-         */
-        private List<AttachmentInfo> documents;
-
-        /**
-         * 正确答案（仅在当前时间超过步骤答题时间后才返回）
-         * 格式：JSON字符串，包含fillBlankCorrectAnswer和tableCellCorrectAnswer
-         */
-        private String correctAnswer;
-
-        /**
-         * 误差范围（用于数值类答案的判分）
-         */
-        private Double tolerance;
+    @EqualsAndHashCode(callSuper = true)
+    public static class DataCollectionDetail extends BaseSubmittedDataCollectionDetailResponse {
     }
 
     /**
      * 附件信息
      */
     @Data
-    public static class AttachmentInfo {
-        /**
-         * 附件ID
-         */
-        private Long id;
-
-        /**
-         * 文件类型（1-照片，2-文档）
-         */
-        private Integer fileType;
-
-        /**
-         * 文件格式
-         */
-        private String fileFormat;
-
-        /**
-         * 原始文件名
-         */
-        private String originalFileName;
-
-        /**
-         * 文件大小（字节）
-         */
-        private Long fileSize;
-
-        /**
-         * 文件备注
-         */
-        private String remark;
-
-        /**
-         * 创建时间
-         */
-        private LocalDateTime createTime;
-
-        /**
-         * 文件下载密钥
-         */
-        private String downloadKey;
+    @EqualsAndHashCode(callSuper = true)
+    public static class AttachmentInfo extends BaseSubmittedDataCollectionDetailResponse.AttachmentInfo {
     }
 }

--- a/src/main/java/com/example/demo/pojo/response/StudentDataCollectionProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/StudentDataCollectionProcedureDetailResponse.java
@@ -1,10 +1,9 @@
 package com.example.demo.pojo.response;
 
-import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
-import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 学生数据收集步骤详情响应
@@ -62,101 +61,15 @@ public class StudentDataCollectionProcedureDetailResponse {
      * 数据收集详情
      */
     @Data
-    public static class DataCollectionDetail {
-        /**
-         * 数据收集ID
-         */
-        private Long id;
-
-        /**
-         * 数据收集类型（1-关键数据，2-表格数据）
-         */
-        private Integer type;
-
-        /**
-         * 数据描述
-         */
-        private String remark;
-
-        /**
-         * 是否需要提交照片
-         */
-        private Boolean needPhoto;
-
-        /**
-         * 是否需要提交文档
-         */
-        private Boolean needDoc;
-
-        /**
-         * 填空答案列表
-         */
-        private List<FillBlankAnswer> fillBlankAnswers;
-
-        /**
-         * 表格答案列表
-         */
-        private List<TableCellAnswer> tableCellAnswers;
-
-        /**
-         * 正确答案（JSON格式）
-         */
-        private String correctAnswer;
-
-        /**
-         * 提交的照片文件列表
-         */
-        private List<AttachmentInfo> photos;
-
-        /**
-         * 提交的文档文件列表
-         */
-        private List<AttachmentInfo> documents;
+    @EqualsAndHashCode(callSuper = true)
+    public static class DataCollectionDetail extends BaseSubmittedDataCollectionDetailResponse {
     }
 
     /**
      * 附件信息
      */
     @Data
-    public static class AttachmentInfo {
-        /**
-         * 附件ID
-         */
-        private Long id;
-
-        /**
-         * 文件类型（1-照片，2-文档）
-         */
-        private Integer fileType;
-
-        /**
-         * 文件格式
-         */
-        private String fileFormat;
-
-        /**
-         * 原始文件名
-         */
-        private String originalFileName;
-
-        /**
-         * 文件大小（字节）
-         */
-        private Long fileSize;
-
-        /**
-         * 文件备注
-         */
-        private String remark;
-
-        /**
-         * 创建时间
-         */
-        private LocalDateTime createTime;
-
-        /**
-         * 文件下载密钥
-         */
-        private String downloadKey;
+    @EqualsAndHashCode(callSuper = true)
+    public static class AttachmentInfo extends BaseSubmittedDataCollectionDetailResponse.AttachmentInfo {
     }
 }

--- a/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.pojo.response;
 
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -132,9 +134,14 @@ public class StudentProcedureDetailResponse {
     private Long dataCollectionType;
 
     /**
-     * 数据描述（类型2时有效）
+     * 填空类型数据描述（类型2且 dataCollectionType=1 时有效）
      */
-    private String dataRemark;
+    private FillBlankRemarkDTO fillBlankRemark;
+
+    /**
+     * 表格类型数据描述（类型2且 dataCollectionType=2 时有效）
+     */
+    private TableRemarkDTO tableRemark;
 
     /**
      * 是否需要提交照片（类型2时有效）

--- a/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailWithAnswerResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailWithAnswerResponse.java
@@ -1,9 +1,8 @@
 package com.example.demo.pojo.response;
 
-import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
-import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.pojo.dto.mapvo.TopicChoice;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -133,62 +132,8 @@ public class StudentProcedureDetailWithAnswerResponse {
      * 数据收集详情
      */
     @Data
-    public static class DataCollectionDetail {
-        /**
-         * 数据收集ID
-         */
-        private Long id;
-
-        /**
-         * 数据收集类型（1-关键数据，2-表格数据）
-         */
-        private Integer type;
-
-        /**
-         * 数据描述
-         */
-        private String remark;
-
-        /**
-         * 是否需要提交照片
-         */
-        private Boolean needPhoto;
-
-        /**
-         * 是否需要提交文档
-         */
-        private Boolean needDoc;
-
-        /**
-         * 填空答案列表
-         */
-        private List<FillBlankAnswer> fillBlankAnswers;
-
-        /**
-         * 表格答案列表
-         */
-        private List<TableCellAnswer> tableCellAnswers;
-
-        /**
-         * 提交的照片文件列表
-         */
-        private List<AttachmentInfo> photos;
-
-        /**
-         * 提交的文档文件列表
-         */
-        private List<AttachmentInfo> documents;
-
-        /**
-         * 正确答案（仅在当前时间超过步骤答题时间后才返回）
-         * 格式：JSON字符串，包含fillBlankCorrectAnswer和tableCellCorrectAnswer
-         */
-        private String correctAnswer;
-
-        /**
-         * 误差范围（用于数值类答案的判分）
-         */
-        private Double tolerance;
+    @EqualsAndHashCode(callSuper = true)
+    public static class DataCollectionDetail extends BaseSubmittedDataCollectionDetailResponse {
     }
 
     /**
@@ -336,45 +281,7 @@ public class StudentProcedureDetailWithAnswerResponse {
      * 附件信息
      */
     @Data
-    public static class AttachmentInfo {
-        /**
-         * 附件ID
-         */
-        private Long id;
-
-        /**
-         * 文件类型（1-照片，2-文档）
-         */
-        private Integer fileType;
-
-        /**
-         * 文件格式
-         */
-        private String fileFormat;
-
-        /**
-         * 原始文件名
-         */
-        private String originalFileName;
-
-        /**
-         * 文件大小（字节）
-         */
-        private Long fileSize;
-
-        /**
-         * 文件备注
-         */
-        private String remark;
-
-        /**
-         * 创建时间
-         */
-        private LocalDateTime createTime;
-
-        /**
-         * 文件下载密钥
-         */
-        private String downloadKey;
+    @EqualsAndHashCode(callSuper = true)
+    public static class AttachmentInfo extends BaseSubmittedDataCollectionDetailResponse.AttachmentInfo {
     }
 }

--- a/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailWithoutAnswerResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/StudentProcedureDetailWithoutAnswerResponse.java
@@ -2,6 +2,7 @@ package com.example.demo.pojo.response;
 
 import com.example.demo.pojo.dto.mapvo.TopicChoice;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 
@@ -86,31 +87,8 @@ public class StudentProcedureDetailWithoutAnswerResponse {
      * 数据收集详情
      */
     @Data
-    public static class DataCollectionDetail {
-        /**
-         * 数据收集ID
-         */
-        private Long id;
-
-        /**
-         * 数据收集类型（1-关键数据，2-表格数据）
-         */
-        private Integer type;
-
-        /**
-         * 数据描述
-         */
-        private String remark;
-
-        /**
-         * 是否需要提交照片
-         */
-        private Boolean needPhoto;
-
-        /**
-         * 是否需要提交文档
-         */
-        private Boolean needDoc;
+    @EqualsAndHashCode(callSuper = true)
+    public static class DataCollectionDetail extends BaseDataCollectionDetailResponse {
     }
 
     /**

--- a/src/main/java/com/example/demo/pojo/response/TeacherDataCollectionProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/TeacherDataCollectionProcedureDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.pojo.response;
 
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -67,9 +69,14 @@ public class TeacherDataCollectionProcedureDetailResponse {
     private Long dataCollectionType;
 
     /**
-     * 数据描述
+     * 填空类型数据描述（dataCollectionType=1 时有效）
      */
-    private String dataRemark;
+    private FillBlankRemarkDTO fillBlankRemark;
+
+    /**
+     * 表格类型数据描述（dataCollectionType=2 时有效）
+     */
+    private TableRemarkDTO tableRemark;
 
     /**
      * 是否需要提交照片

--- a/src/main/java/com/example/demo/pojo/response/TeacherProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/TeacherProcedureDetailResponse.java
@@ -1,5 +1,7 @@
 package com.example.demo.pojo.response;
 
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -96,9 +98,14 @@ public class TeacherProcedureDetailResponse {
     private Long dataCollectionType;
 
     /**
-     * 数据描述（类型2时有效）
+     * 填空类型数据描述（类型2且 dataCollectionType=1 时有效）
      */
-    private String dataRemark;
+    private FillBlankRemarkDTO fillBlankRemark;
+
+    /**
+     * 表格类型数据描述（类型2且 dataCollectionType=2 时有效）
+     */
+    private TableRemarkDTO tableRemark;
 
     /**
      * 是否需要提交照片（类型2时有效）

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -8,9 +8,11 @@ import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.pojo.dto.mapvo.TopicChoice;
 import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.request.ClassProcedureDetailRequest;
+import com.example.demo.pojo.response.BaseSubmittedDataCollectionDetailResponse;
 import com.example.demo.pojo.response.ClassStudentProcedureDetailResponse;
 import com.example.demo.pojo.response.StudentProcedureDetailWithAnswerResponse;
 import com.example.demo.util.AnswerMapJSONUntil;
+import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.TopicAnswerContractUtil;
 import com.example.demo.util.ProcedureTimeCalculator;
 import lombok.RequiredArgsConstructor;
@@ -419,7 +421,7 @@ public class ClassStudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 detail.setTolerance(dataCollection.getTolerance());
@@ -430,12 +432,12 @@ public class ClassStudentProcedureQueryService {
                 attachmentWrapper.eq(StudentProcedureAttachment::getStudentUsername, username);
                 List<StudentProcedureAttachment> attachments = studentProcedureAttachmentMapper.selectList(attachmentWrapper);
 
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> photos = new ArrayList<>();
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> documents = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> photos = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> documents = new ArrayList<>();
 
                 for (StudentProcedureAttachment attachment : attachments) {
-                    StudentProcedureDetailWithAnswerResponse.AttachmentInfo info =
-                        new StudentProcedureDetailWithAnswerResponse.AttachmentInfo();
+                    BaseSubmittedDataCollectionDetailResponse.AttachmentInfo info =
+                        new BaseSubmittedDataCollectionDetailResponse.AttachmentInfo();
                     info.setId(attachment.getId());
                     info.setFileType(attachment.getFileType());
                     info.setFileFormat(attachment.getFileFormat());
@@ -505,7 +507,7 @@ public class ClassStudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 return detail;
@@ -864,6 +866,22 @@ public class ClassStudentProcedureQueryService {
         } catch (Exception e) {
             log.error("解析题目选项失败, choices: {}", choices, e);
             return new ArrayList<>();
+        }
+    }
+
+    private void fillDataCollectionRemark(
+            StudentProcedureDetailWithAnswerResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
         }
     }
 }

--- a/src/main/java/com/example/demo/service/StudentExperimentService.java
+++ b/src/main/java/com/example/demo/service/StudentExperimentService.java
@@ -21,6 +21,7 @@ import com.example.demo.pojo.entity.Topic;
 import com.example.demo.pojo.entity.VideoFile;
 import com.example.demo.pojo.response.StudentExperimentDetailResponse;
 import com.example.demo.pojo.response.StudentProcedureDetailResponse;
+import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.ProcedureTimeCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -288,7 +289,7 @@ public class StudentExperimentService {
         DataCollection dataCollection = dataCollectionMapper.selectById(procedure.getDataCollectionId());
         if (dataCollection != null) {
             response.setDataCollectionType(dataCollection.getType());
-            response.setDataRemark(dataCollection.getRemark());
+            fillDataCollectionRemark(response, dataCollection);
             response.setDataNeedPhoto(dataCollection.getNeedPhoto());
             response.setDataNeedDoc(dataCollection.getNeedDoc());
         }
@@ -355,32 +356,51 @@ public class StudentExperimentService {
             ExperimentalProcedure currentProcedure,
             String studentUsername,
             String classCode) {
-
-        // 第一个步骤没有前置步骤
-        if (currentProcedure.getNumber() == 1) {
+        if (currentProcedure.getNumber() == null || currentProcedure.getNumber() <= 1) {
             return true;
         }
 
-        // 查询所有步骤
-        List<ExperimentalProcedure> allProcedures = experimentalProcedureService
-                .getByExperimentId(currentProcedure.getExperimentId());
+        List<StudentExperimentalProcedure> studentProcedures =
+                studentExperimentalProcedureService.getByStudentAndExperiment(
+                        studentUsername,
+                        classCode,
+                        currentProcedure.getExperimentId());
 
-        // 检查序号小于当前步骤的步骤
-        for (ExperimentalProcedure procedure : allProcedures) {
-            if (procedure.getNumber() >= currentProcedure.getNumber()) {
-                break;
-            }
+        if (studentProcedures == null || studentProcedures.isEmpty()) {
+            return false;
+        }
 
-            // 只要有一个不可跳过的步骤未完成，则返回 false
-            if (!Boolean.TRUE.equals(procedure.getIsSkip())) {
-                boolean isCompleted = studentExperimentalProcedureService
-                        .isProcedureCompleted(studentUsername, classCode, procedure.getId());
-                if (!isCompleted) {
+        List<ExperimentalProcedure> procedures =
+                experimentalProcedureService.getByExperimentId(currentProcedure.getExperimentId());
+        if (procedures == null || procedures.isEmpty()) {
+            return true;
+        }
+
+        for (ExperimentalProcedure procedure : procedures) {
+            if (procedure.getNumber() != null && procedure.getNumber() < currentProcedure.getNumber()) {
+                boolean completed = studentProcedures.stream()
+                        .anyMatch(sp -> sp.getExperimentalProcedureId().equals(procedure.getId())
+                                && sp.getAnswer() != null
+                                && !sp.getAnswer().trim().isEmpty());
+                if (!completed) {
                     return false;
                 }
             }
         }
-
         return true;
+    }
+
+    private void fillDataCollectionRemark(StudentProcedureDetailResponse response, DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            response.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(null);
+        }
     }
 }

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -7,9 +7,11 @@ import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
 import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.pojo.dto.mapvo.TopicChoice;
 import com.example.demo.pojo.entity.*;
+import com.example.demo.pojo.response.BaseSubmittedDataCollectionDetailResponse;
 import com.example.demo.pojo.response.StudentProcedureDetailWithAnswerResponse;
 import com.example.demo.pojo.response.StudentProcedureDetailWithoutAnswerResponse;
 import com.example.demo.util.AnswerMapJSONUntil;
+import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.ProcedureTimeCalculator;
 import com.example.demo.util.TimedQuizKeyGenerator;
 import com.example.demo.util.TopicAnswerContractUtil;
@@ -283,7 +285,7 @@ public class StudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 detail.setTolerance(dataCollection.getTolerance());
@@ -294,12 +296,12 @@ public class StudentProcedureQueryService {
                 attachmentWrapper.eq(StudentProcedureAttachment::getStudentUsername, username);
                 List<StudentProcedureAttachment> attachments = studentProcedureAttachmentMapper.selectList(attachmentWrapper);
 
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> photos = new ArrayList<>();
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> documents = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> photos = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> documents = new ArrayList<>();
 
                 for (StudentProcedureAttachment attachment : attachments) {
-                    StudentProcedureDetailWithAnswerResponse.AttachmentInfo info =
-                        new StudentProcedureDetailWithAnswerResponse.AttachmentInfo();
+                    BaseSubmittedDataCollectionDetailResponse.AttachmentInfo info =
+                        new BaseSubmittedDataCollectionDetailResponse.AttachmentInfo();
                     info.setId(attachment.getId());
                     info.setFileType(attachment.getFileType());
                     info.setFileFormat(attachment.getFileFormat());
@@ -370,7 +372,7 @@ public class StudentProcedureQueryService {
                     new StudentProcedureDetailWithoutAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 response.setDataCollectionDetail(detail);
@@ -750,5 +752,37 @@ public class StudentProcedureQueryService {
             }
         }
         return new ArrayList<>();
+    }
+
+    private void fillDataCollectionRemark(
+            StudentProcedureDetailWithAnswerResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
+        }
+    }
+
+    private void fillDataCollectionRemark(
+            StudentProcedureDetailWithoutAnswerResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
+        }
     }
 }

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -34,8 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +52,6 @@ public class TeacherProcedureCreationService {
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
     private final TopicMapper topicMapper;
-    private final ObjectMapper objectMapper;
 
     /**
      * 获取实验的最大步骤号
@@ -188,17 +185,17 @@ public class TeacherProcedureCreationService {
         String correctAnswer;
         if (request.getDataType() == 1) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                    dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                    dataFieldsMap, fieldTolerances);
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                     request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                    tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                    cellTolerances, request.getTableColumnTolerances());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
         } else {
-            remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                    request.getTableRowHeaders(), request.getTableColumnHeaders());
-            correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+            // 文件上传类型（type=3）：remark 无额外数据
+            remark = "{}";
+            correctAnswer = null;
         }
 
         // 3. 创建数据收集记录
@@ -433,17 +430,17 @@ public class TeacherProcedureCreationService {
                 String correctAnswer;
                 if (request.getDataType() == 1) {
                     remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                            dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                            dataFieldsMap, fieldTolerances);
                     correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
                 } else if (request.getDataType() == 2) {
                     remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                             request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                            tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                            cellTolerances, request.getTableColumnTolerances());
                     correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
                 } else {
-                    remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                            request.getTableRowHeaders(), request.getTableColumnHeaders());
-                    correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+                    // 文件上传类型（type=3）：remark 无额外数据
+                    remark = "{}";
+                    correctAnswer = null;
                 }
 
                 dataCollection.setRemark(remark);
@@ -700,17 +697,17 @@ public class TeacherProcedureCreationService {
         String correctAnswer;
         if (request.getDataType() == 1) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                    dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                    dataFieldsMap, fieldTolerances);
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                     request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                    tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                    cellTolerances, request.getTableColumnTolerances());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
         } else {
-            remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                    request.getTableRowHeaders(), request.getTableColumnHeaders());
-            correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+            // 文件上传类型（type=3）：remark 无额外数据
+            remark = "{}";
+            correctAnswer = null;
         }
 
         // 创建数据收集记录
@@ -867,53 +864,6 @@ public class TeacherProcedureCreationService {
         }
         if (startTime.isAfter(endTime)) {
             throw new com.example.demo.exception.BusinessException(400, "开始时间不能晚于结束时间");
-        }
-    }
-
-    /**
-     * 构建数据收集的remark（数据描述JSON）
-     */
-    private String buildDataCollectionRemark(Integer dataType,
-                                             Map<String, String> dataFields,
-                                             List<String> tableRowHeaders,
-                                             List<String> tableColumnHeaders) {
-        try {
-            Map<String, Object> remarkData = new HashMap<>();
-
-            if (dataType == 1) {
-                // 填空类型：保存数据字段名称列表
-                remarkData.put("dataFields", dataFields != null ? dataFields.keySet() : List.of());
-            } else if (dataType == 2) {
-                // 表格类型：保存表格���构
-                remarkData.put("tableRowHeaders", tableRowHeaders);
-                remarkData.put("tableColumnHeaders", tableColumnHeaders);
-            }
-
-            return objectMapper.writeValueAsString(remarkData);
-        } catch (Exception e) {
-            log.error("构建数据描述JSON失败", e);
-            throw new com.example.demo.exception.BusinessException(500, "构建数据描述失败");
-        }
-    }
-
-    /**
-     * 构建数据收集的correctAnswer（正确答案JSON）
-     */
-    private String buildCorrectAnswerJson(Integer dataType,
-                                          Map<String, String> dataFields,
-                                          Map<String, String> tableCellAnswers) {
-        try {
-            if (dataType == 1) {
-                // 填空类型：使用 dataFields 作为正确答案
-                return objectMapper.writeValueAsString(dataFields);
-            } else if (dataType == 2) {
-                // 表格类型：使用 tableCellAnswers 作为正确答案
-                return objectMapper.writeValueAsString(tableCellAnswers);
-            }
-            return null;
-        } catch (Exception e) {
-            log.error("构建正确答案JSON失败", e);
-            throw new com.example.demo.exception.BusinessException(500, "构建正确答案失败");
         }
     }
 

--- a/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
@@ -24,6 +24,7 @@ import com.example.demo.pojo.response.TeacherDataCollectionProcedureDetailRespon
 import com.example.demo.pojo.response.TeacherProcedureDetailResponse;
 import com.example.demo.pojo.response.TeacherTopicProcedureDetailResponse;
 import com.example.demo.pojo.response.TeacherVideoProcedureDetailResponse;
+import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.ProcedureTimeCalculator;
 import com.example.demo.util.TopicAnswerContractUtil;
 import lombok.RequiredArgsConstructor;
@@ -192,7 +193,7 @@ public class TeacherProcedureQueryService {
         if (dataCollection != null) {
             response.setDataCollectionId(dataCollection.getId());
             response.setDataCollectionType(dataCollection.getType());
-            response.setDataRemark(dataCollection.getRemark());
+            fillDataCollectionRemark(response, dataCollection);
             response.setDataNeedPhoto(dataCollection.getNeedPhoto());
             response.setDataNeedDoc(dataCollection.getNeedDoc());
             response.setTolerance(dataCollection.getTolerance());
@@ -561,10 +562,38 @@ public class TeacherProcedureQueryService {
         if (dataCollection != null) {
             response.setDataCollectionId(dataCollection.getId());
             response.setDataCollectionType(dataCollection.getType());
-            response.setDataRemark(dataCollection.getRemark());
+            fillDataCollectionRemark(response, dataCollection);
             response.setDataNeedPhoto(dataCollection.getNeedPhoto());
             response.setDataNeedDoc(dataCollection.getNeedDoc());
             response.setTolerance(dataCollection.getTolerance());
+        }
+    }
+
+    private void fillDataCollectionRemark(TeacherProcedureDetailResponse response, DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            response.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(null);
+        }
+    }
+
+    private void fillDataCollectionRemark(TeacherDataCollectionProcedureDetailResponse response, DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            response.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            response.setFillBlankRemark(null);
+            response.setTableRemark(null);
         }
     }
 

--- a/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
@@ -8,6 +8,7 @@ import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.mapper.*;
 import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.response.*;
+import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.TopicAnswerContractUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -964,7 +965,7 @@ public class TeacherStudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
 
@@ -974,12 +975,12 @@ public class TeacherStudentProcedureQueryService {
                 attachmentWrapper.eq(StudentProcedureAttachment::getStudentUsername, username);
                 List<StudentProcedureAttachment> attachments = studentProcedureAttachmentMapper.selectList(attachmentWrapper);
 
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> photos = new ArrayList<>();
-                List<StudentProcedureDetailWithAnswerResponse.AttachmentInfo> documents = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> photos = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> documents = new ArrayList<>();
 
                 for (StudentProcedureAttachment attachment : attachments) {
-                    StudentProcedureDetailWithAnswerResponse.AttachmentInfo info =
-                        new StudentProcedureDetailWithAnswerResponse.AttachmentInfo();
+                    BaseSubmittedDataCollectionDetailResponse.AttachmentInfo info =
+                        new BaseSubmittedDataCollectionDetailResponse.AttachmentInfo();
                     info.setId(attachment.getId());
                     info.setFileType(attachment.getFileType());
                     info.setFileFormat(attachment.getFileFormat());
@@ -1124,7 +1125,7 @@ public class TeacherStudentProcedureQueryService {
                     new StudentProcedureDetailWithoutAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 response.setDataCollectionDetail(detail);
@@ -1243,6 +1244,54 @@ public class TeacherStudentProcedureQueryService {
      */
     private Map<Long, String> parseTopicAnswers(String answerJson) {
         return com.example.demo.util.AnswerMapJSONUntil.parseTopicData(answerJson);
+    }
+
+    private void fillDataCollectionRemark(
+            StudentProcedureDetailWithAnswerResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
+        }
+    }
+
+    private void fillDataCollectionRemark(
+            StudentProcedureDetailWithoutAnswerResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
+        }
+    }
+
+    private void fillDataCollectionRemark(
+            StudentDataCollectionProcedureDetailResponse.DataCollectionDetail detail,
+            DataCollection dataCollection) {
+        Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
+        if (Integer.valueOf(1).equals(type)) {
+            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark()));
+            detail.setTableRemark(null);
+        } else if (Integer.valueOf(2).equals(type)) {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(DataCollectionDataUtil.parseTableRemark(dataCollection.getRemark()));
+        } else {
+            detail.setFillBlankRemark(null);
+            detail.setTableRemark(null);
+        }
     }
 
     // ============================================
@@ -1399,7 +1448,7 @@ public class TeacherStudentProcedureQueryService {
                     new com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
 
@@ -1409,12 +1458,12 @@ public class TeacherStudentProcedureQueryService {
                 attachmentWrapper.eq(StudentProcedureAttachment::getStudentUsername, studentUsername);
                 List<StudentProcedureAttachment> attachments = studentProcedureAttachmentMapper.selectList(attachmentWrapper);
 
-                List<com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.AttachmentInfo> photos = new ArrayList<>();
-                List<com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.AttachmentInfo> documents = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> photos = new ArrayList<>();
+                List<BaseSubmittedDataCollectionDetailResponse.AttachmentInfo> documents = new ArrayList<>();
 
                 for (StudentProcedureAttachment attachment : attachments) {
-                    com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.AttachmentInfo info =
-                        new com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.AttachmentInfo();
+                    BaseSubmittedDataCollectionDetailResponse.AttachmentInfo info =
+                        new BaseSubmittedDataCollectionDetailResponse.AttachmentInfo();
                     info.setId(attachment.getId());
                     info.setFileType(attachment.getFileType());
                     info.setFileFormat(attachment.getFileFormat());
@@ -1502,7 +1551,7 @@ public class TeacherStudentProcedureQueryService {
                     new com.example.demo.pojo.response.StudentDataCollectionProcedureDetailResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                detail.setRemark(dataCollection.getRemark());
+                fillDataCollectionRemark(detail, dataCollection);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
 

--- a/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
+++ b/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
@@ -1,5 +1,7 @@
 package com.example.demo.util;
 
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +11,14 @@ import java.util.Map;
 
 /**
  * 数据收集步骤数据转换工具类
- * 用于将结构化的填空和表格数据转换为JSON格式存储
+ * 用于将结构化的填空和表格数据转换为JSON格式存储到 remark 字段
+ *
+ * remark JSON 格式（按数据类型区分）：
+ * - 填空类型（type=1）：{"fillBlanks":{"field":"value"},"fieldTolerances":{"field":0.1}}
+ * - 表格类型（type=2）：{"tableRowHeaders":["A"],"tableColumnHeaders":["1"],"tableCellAnswers":{"A1":"value"},...}
+ * - 文件类型（type=3）：{}
+ *
+ * 注意：dataType 已从 remark 中移除，请通过 DataCollection.type 获取数据类型
  */
 @Slf4j
 public class DataCollectionDataUtil {
@@ -17,106 +26,20 @@ public class DataCollectionDataUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
-     * 数据收集数据结构
-     */
-    public static class DataCollectionData {
-        /** 数据类型（1-填空，2-表格） */
-        private Integer dataType;
-
-        /** 填空数据（Map<需要的数据, 数据答案>） */
-        private Map<String, String> fillBlanks;
-
-        /** 表格行表头 */
-        private List<String> tableRowHeaders;
-
-        /** 表格列表头 */
-        private List<String> tableColumnHeaders;
-
-        /** 表格单元格答案（Map<表格坐标, 答案>） */
-        private Map<String, String> tableCellAnswers;
-
-        public Integer getDataType() {
-            return dataType;
-        }
-
-        public void setDataType(Integer dataType) {
-            this.dataType = dataType;
-        }
-
-        public Map<String, String> getFillBlanks() {
-            return fillBlanks;
-        }
-
-        public void setFillBlanks(Map<String, String> fillBlanks) {
-            this.fillBlanks = fillBlanks;
-        }
-
-        public List<String> getTableRowHeaders() {
-            return tableRowHeaders;
-        }
-
-        public void setTableRowHeaders(List<String> tableRowHeaders) {
-            this.tableRowHeaders = tableRowHeaders;
-        }
-
-        public List<String> getTableColumnHeaders() {
-            return tableColumnHeaders;
-        }
-
-        public void setTableColumnHeaders(List<String> tableColumnHeaders) {
-            this.tableColumnHeaders = tableColumnHeaders;
-        }
-
-        public Map<String, String> getTableCellAnswers() {
-            return tableCellAnswers;
-        }
-
-        public void setTableCellAnswers(Map<String, String> tableCellAnswers) {
-            this.tableCellAnswers = tableCellAnswers;
-        }
-    }
-
-    /**
-     * 将填空类型数据转换为JSON
-     *
-     * @param fillBlanks 填空数据
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @return JSON字符串
-     */
-    public static String convertFillBlanksToJson(Map<String, String> fillBlanks,
-                                                  Map<String, String> correctAnswer,
-                                                  Double tolerance) {
-        return convertFillBlanksToJson(fillBlanks, correctAnswer, tolerance, null);
-    }
-
-    /**
      * 将填空类型数据转换为JSON（支持字段级误差）
      *
-     * @param fillBlanks 填空数据
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param fieldTolerances 字段级误差映射
+     * @param fillBlanks      填空数据（字段名 -> 值）
+     * @param fieldTolerances 字段级误差映射（可选）
      * @return JSON字符串
      */
     public static String convertFillBlanksToJson(Map<String, String> fillBlanks,
-                                                  Map<String, String> correctAnswer,
-                                                  Double tolerance,
                                                   Map<String, Double> fieldTolerances) {
-        DataCollectionData data = new DataCollectionData();
-        data.setDataType(1);
-        data.setFillBlanks(fillBlanks);
-
         try {
-            // 将正确答案和误差也存储到同一个JSON中
-            Map<String, Object> result = new java.util.HashMap<>();
-            result.put("dataType", 1);
-            result.put("fillBlanks", fillBlanks);
-            result.put("correctAnswer", correctAnswer);
-            result.put("tolerance", tolerance);
-            result.put("fieldTolerances", fieldTolerances);
-
-            return objectMapper.writeValueAsString(result);
+            FillBlankRemarkDTO dto = FillBlankRemarkDTO.builder()
+                    .fillBlanks(fillBlanks)
+                    .fieldTolerances(fieldTolerances)
+                    .build();
+            return objectMapper.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
             log.error("转换填空数据为JSON失败", e);
             throw new RuntimeException("转换填空数据为JSON失败", e);
@@ -124,74 +47,29 @@ public class DataCollectionDataUtil {
     }
 
     /**
-     * 将表格类型数据转换为JSON
-     *
-     * @param tableRowHeaders 表格行表头
-     * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @return JSON字符串
-     */
-    public static String convertTableToJson(List<String> tableRowHeaders,
-                                           List<String> tableColumnHeaders,
-                                           Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance) {
-        return convertTableToJson(tableRowHeaders, tableColumnHeaders, tableCellAnswers, correctAnswer, tolerance, null);
-    }
-
-    /**
-     * 将表格类型数据转换为JSON（支持单元格级误差）
-     *
-     * @param tableRowHeaders 表格行表头
-     * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param cellTolerances 单元格级误差映射
-     * @return JSON字符串
-     */
-    public static String convertTableToJson(List<String> tableRowHeaders,
-                                           List<String> tableColumnHeaders,
-                                           Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance,
-                                           Map<String, Double> cellTolerances) {
-        return convertTableToJson(tableRowHeaders, tableColumnHeaders, tableCellAnswers, correctAnswer, tolerance, cellTolerances, null);
-    }
-
-    /**
      * 将表格类型数据转换为JSON（支持单元格级和列级误差）
      *
-     * @param tableRowHeaders 表格行表头
+     * @param tableRowHeaders    表格行表头
      * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param cellTolerances 单元格级误差映射
-     * @param columnTolerances 列级误差映射
+     * @param tableCellAnswers   表格单元格答案
+     * @param cellTolerances     单元格级误差映射（可选）
+     * @param columnTolerances   列级误差映射（可选）
      * @return JSON字符串
      */
     public static String convertTableToJson(List<String> tableRowHeaders,
                                            List<String> tableColumnHeaders,
                                            Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance,
                                            Map<String, Double> cellTolerances,
                                            Map<String, Double> columnTolerances) {
         try {
-            Map<String, Object> result = new java.util.HashMap<>();
-            result.put("dataType", 2);
-            result.put("tableRowHeaders", tableRowHeaders);
-            result.put("tableColumnHeaders", tableColumnHeaders);
-            result.put("tableCellAnswers", tableCellAnswers);
-            result.put("correctAnswer", correctAnswer);
-            result.put("tolerance", tolerance);
-            result.put("cellTolerances", cellTolerances);
-            result.put("columnTolerances", columnTolerances);
-
-            return objectMapper.writeValueAsString(result);
+            TableRemarkDTO dto = TableRemarkDTO.builder()
+                    .tableRowHeaders(tableRowHeaders)
+                    .tableColumnHeaders(tableColumnHeaders)
+                    .tableCellAnswers(tableCellAnswers)
+                    .cellTolerances(cellTolerances)
+                    .columnTolerances(columnTolerances)
+                    .build();
+            return objectMapper.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
             log.error("转换表格数据为JSON失败", e);
             throw new RuntimeException("转换表格数据为JSON失败", e);
@@ -214,24 +92,47 @@ public class DataCollectionDataUtil {
     }
 
     /**
+     * 从 remark JSON 中解析为填空类型 DTO
+     *
+     * @param remarkJson remark JSON字符串
+     * @return 填空类型 DTO，解析失败返回 null
+     */
+    public static FillBlankRemarkDTO parseFillBlankRemark(String remarkJson) {
+        try {
+            return objectMapper.readValue(remarkJson, FillBlankRemarkDTO.class);
+        } catch (JsonProcessingException e) {
+            log.error("解析填空类型 remark 失败", e);
+            return null;
+        }
+    }
+
+    /**
+     * 从 remark JSON 中解析为表格类型 DTO
+     *
+     * @param remarkJson remark JSON字符串
+     * @return 表格类型 DTO，解析失败返回 null
+     */
+    public static TableRemarkDTO parseTableRemark(String remarkJson) {
+        try {
+            return objectMapper.readValue(remarkJson, TableRemarkDTO.class);
+        } catch (JsonProcessingException e) {
+            log.error("解析表格类型 remark 失败", e);
+            return null;
+        }
+    }
+
+    /**
      * 从JSON中解析字段级误差映射
      *
      * @param json 数据收集JSON字符串
      * @return 字段级误差映射
      */
     public static Map<String, Double> parseFieldTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode fieldTolerancesNode = root.get("fieldTolerances");
-            if (fieldTolerancesNode == null || fieldTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(fieldTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析字段级误差失败", e);
+        FillBlankRemarkDTO dto = parseFillBlankRemark(json);
+        if (dto == null || dto.getFieldTolerances() == null) {
             return Map.of();
         }
+        return dto.getFieldTolerances();
     }
 
     /**
@@ -241,18 +142,11 @@ public class DataCollectionDataUtil {
      * @return 单元格级误差映射
      */
     public static Map<String, Double> parseCellTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode cellTolerancesNode = root.get("cellTolerances");
-            if (cellTolerancesNode == null || cellTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(cellTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析单元格级误差失败", e);
+        TableRemarkDTO dto = parseTableRemark(json);
+        if (dto == null || dto.getCellTolerances() == null) {
             return Map.of();
         }
+        return dto.getCellTolerances();
     }
 
     /**
@@ -262,17 +156,10 @@ public class DataCollectionDataUtil {
      * @return 列级误差映射
      */
     public static Map<String, Double> parseColumnTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode columnTolerancesNode = root.get("columnTolerances");
-            if (columnTolerancesNode == null || columnTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(columnTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析列级误差失败", e);
+        TableRemarkDTO dto = parseTableRemark(json);
+        if (dto == null || dto.getColumnTolerances() == null) {
             return Map.of();
         }
+        return dto.getColumnTolerances();
     }
 }

--- a/src/main/resources/sql/add_unique_constraints_migration.sql
+++ b/src/main/resources/sql/add_unique_constraints_migration.sql
@@ -1,0 +1,39 @@
+-- 数据库迁移：为 selectOne 依赖的高风险表补充唯一约束
+-- 执行时间：2026-04-04
+-- 说明：
+-- 1. 只为业务上明确应该唯一的数据加约束
+-- 2. classes_experiment / classroom_quiz 仍需业务层保证，不能用简单唯一索引硬兜
+-- 1. users 表：微信 OpenID 应唯一
+-- 执行前请先排查重复数据：
+-- SELECT wx_openid, COUNT(*) FROM users WHERE wx_openid IS NOT NULL AND wx_openid <> '' GROUP BY wx_openid HAVING COUNT(*) > 1;
+ALTER TABLE `users`
+ADD UNIQUE KEY `uk_wx_openid` (`wx_openid`);
+
+-- 2. classes 表：补充验证码字段并保证唯一
+ALTER TABLE `classes`
+ADD COLUMN `verification_code` VARCHAR(20) NULL COMMENT '班级验证码' AFTER `class_name`;
+
+-- 为已有班级回填验证码，使用主键保证唯一
+UPDATE `classes`
+SET `verification_code` = CONCAT('CLS', `id`)
+WHERE `verification_code` IS NULL OR `verification_code` = '';
+
+ALTER TABLE `classes`
+MODIFY COLUMN `verification_code` VARCHAR(20) NOT NULL COMMENT '班级验证码',
+ADD UNIQUE KEY `uk_verification_code` (`verification_code`);
+
+-- 3. student_experimental_procedure 表：同一学生对同一步骤只能有一条记录
+-- 执行前请先排查重复数据：
+-- SELECT experimental_procedure_id, student_username, COUNT(*) FROM student_experimental_procedure GROUP BY experimental_procedure_id, student_username HAVING COUNT(*) > 1;
+ALTER TABLE `student_experimental_procedure`
+ADD UNIQUE KEY `uk_procedure_student` (`experimental_procedure_id`, `student_username`);
+
+-- 4. data_collection 表：一个实验步骤只能对应一条数据收集配置
+-- 执行前请先排查重复数据：
+-- SELECT experimental_procedure_id, COUNT(*) FROM data_collection GROUP BY experimental_procedure_id HAVING COUNT(*) > 1;
+ALTER TABLE `data_collection`
+ADD UNIQUE KEY `uk_procedure_data` (`experimental_procedure_id`);
+
+-- 5. 以下两类风险不通过数据库唯一约束处理：
+-- classes_experiment：同一课程/实验可以在不同时间、不同班级组合下重复开课
+-- classroom_quiz：同一班级实验允许有多次历史小测，只要求“进行中”最多一个

--- a/src/main/resources/sql/remove_datatype_from_remark_migration.sql
+++ b/src/main/resources/sql/remove_datatype_from_remark_migration.sql
@@ -1,0 +1,151 @@
+-- ============================================================
+-- 数据迁移：规范化 data_collection.remark JSON 格式
+-- 执行时间：待定
+-- 说明：
+--   1. 早期旧格式（id=1,2,3）：{"dataFields":["Uab","I1"]}
+--      → 迁移为 {"fillBlanks":{"Uab":"","I1":""}}
+--      （correct_answer 列已存储正确答案，remark 中仅保留字段名）
+--
+--   2. 含冗余字段的新格式（id=7,9）：
+--      {"fillBlanks":...,"dataType":1,"correctAnswer":...,"tolerance":...}
+--      → 移除 dataType、correctAnswer、tolerance 冗余字段
+--
+--   3. 空记录（id=4,5,6,8）：type=3 文件上传，remark='{}'
+--      → 无需处理
+-- ============================================================
+
+-- ============================================================
+-- 第一部分：迁移前验证
+-- ============================================================
+
+-- 1. 查看所有 remark 数据
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != ''
+ORDER BY id;
+
+-- 2. 统计旧格式记录数（含 dataFields 但不含 fillBlanks）
+SELECT '旧格式(dataFields)记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 3. 统计含冗余字段的记录数（含 dataType 或 correctAnswer 或 tolerance）
+SELECT '含冗余字段记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- ============================================================
+-- 第二部分：备份数据（强烈建议）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS data_collection_remark_backup_20260415 AS
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != '';
+
+SELECT '备份行数' AS info, COUNT(*) AS total
+FROM data_collection_remark_backup_20260415;
+
+-- ============================================================
+-- 第三部分：迁移步骤一 — 旧格式 dataFields → fillBlanks
+-- ============================================================
+-- 将 {"dataFields":["Uab","I1","Us"]} 转为 {"fillBlanks":{"Uab":"","I1":"","Us":""}}
+-- 正确答案已存在于 correct_answer 列，remark 仅需保留字段名映射
+
+UPDATE data_collection
+SET remark = JSON_OBJECT(
+    'fillBlanks',
+    (
+        SELECT JSON_OBJECTAGG(field, '')
+        FROM JSON_TABLE(
+            JSON_EXTRACT(remark, '$.dataFields'),
+            '$[*]' COLUMNS (field VARCHAR(255) PATH '$')
+        ) AS jt
+    )
+)
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 验证步骤一
+SELECT '步骤一迁移后：旧格式剩余' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- ============================================================
+-- 第四部分：迁移步骤二 — 移除冗余字段 dataType/correctAnswer/tolerance
+-- ============================================================
+
+UPDATE data_collection
+SET remark = JSON_REMOVE(
+    JSON_REMOVE(
+        JSON_REMOVE(remark, '$.dataType'),
+        '$.correctAnswer'
+    ),
+    '$.tolerance'
+)
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- 验证步骤二
+SELECT '步骤二迁移后：仍含冗余字段的记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- ============================================================
+-- 第五部分：迁移后最终验证
+-- ============================================================
+
+-- 1. 查看所有迁移后的 remark 数据
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != ''
+ORDER BY id;
+
+-- 2. 确认所有填空类型记录都使用 fillBlanks 格式
+SELECT id, type, remark
+FROM data_collection
+WHERE type = 1
+  AND remark IS NOT NULL
+  AND remark != ''
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 预期结果：0 行（所有填空类型都已包含 fillBlanks）
+
+-- ============================================================
+-- 第六部分：回滚方案（如需回退）
+-- ============================================================
+
+-- UPDATE data_collection dc
+-- INNER JOIN data_collection_remark_backup_20260415 bak ON dc.id = bak.id
+-- SET dc.remark = bak.remark;
+
+-- ============================================================
+-- 第七部分：清理（确认迁移成功后执行）
+-- ============================================================
+
+-- DROP TABLE IF EXISTS data_collection_remark_backup_20260415;


### PR DESCRIPTION
将数据收集类 DataCollectionDetail 抽为公共基类，统一学生端、教师端与班级维度的返回结构，并修复附件类型继承后的编译问题。前端需关注这些接口的结构适配：/api/student/procedure-submissions/completed、/api/student/procedure-submissions/uncompleted、/api/teacher/students/{studentUsername}/procedures/data-collection/{procedureId}/completed、/api/teacher/students/{studentUsername}/procedures/data-collection/{procedureId}/uncompleted、/api/teacher/class-procedure-details/data-collection/completed、/api/teacher/class-procedure-details/data-collection/uncompleted、/api/teacher/procedures/data-collection/{procedureId}、/api/teacher/procedures/{procedureId}、/api/teacher/procedures/experiment/{experimentId}。