### PR TITLE
重构表格数据收集 remark 与坐标格式

### DIFF
--- a/docs/table-data-collection-format-spec.md
+++ b/docs/table-data-collection-format-spec.md
@@ -1,0 +1,305 @@
+# 表格类型数据收集格式约定书
+
+> 本文档规定表格类型（type=2）数据收集步骤在前后端交互、数据库存储、自动判分中的数据格式标准。所有参与表格类型数据收集功能的开发人员必须遵守此约定。
+
+---
+
+## 一、基本概念
+
+表格类型数据收集用于需要多行多列结构化数据填写的实验步骤。表格由**行表头**和**列表头**定义结构，单元格通过 **`rowIndex`（行索引）+ `columnIndex`（列索引）** 两个整型字段定位。
+
+### 索引规则
+
+- `rowIndex` 和 `columnIndex` **从 0 开始**
+- `rowIndex` 对应 `tableRowHeaders` 数组下标
+- `columnIndex` 对应 `tableColumnHeaders` 数组下标
+
+### 示例表格
+
+| | 温度（columnIndex=0） | 湿度（columnIndex=1） | 压力（columnIndex=2） |
+|---|---|---|---|
+| **实验1（rowIndex=0）** | 3.5 | 60 | 101.3 |
+| **实验2（rowIndex=1）** | 4.2 | 55 | 102.1 |
+| **实验3（rowIndex=2）** | 3.8 | 58 | 100.5 |
+
+对应：
+- `tableRowHeaders`: `["实验1", "实验2", "实验3"]`
+- `tableColumnHeaders`: `["温度", "湿度", "压力"]`
+
+---
+
+## 二、教师端 — 创建/修改表格结构
+
+### 2.1 接口说明
+
+教师通过以下接口创建或修改表格类型数据收集步骤：
+
+| 操作 | 接口 |
+|---|---|
+| 创建 | `POST /api/teacher/procedure/data-collection/create` |
+| 更新 | `PUT /api/teacher/procedure/data-collection/update` |
+| 插入 | `POST /api/teacher/procedure/data-collection/insert` |
+
+三个接口的表格相关字段完全一致。
+
+### 2.2 请求参数（表格相关字段）
+
+| 字段名 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `dataType` | `Integer` | 是 | 固定传 `2`（表格类型） |
+| `tableRowHeaders` | `List<String>` | 是 | 行表头名称列表，不可为空 |
+| `tableColumnHeaders` | `List<String>` | 是 | 列表头名称列表，不可为空 |
+| `tableCellAnswers` | `List<TableCellAnswer>` | 是 | 每个单元格的正确答案，不可为空 |
+| `tableColumnTolerances` | `List<ColumnTolerance>` | 否 | 列级误差配置，可选 |
+| `tolerance` | `Double` | 否 | 步骤级误差百分比（兜底），如 `5` 表示 ±5% |
+
+### 2.3 TableCellAnswer 对象格式
+
+教师设置单元格正确答案时使用：
+
+```json
+{
+  "rowIndex": 0,
+  "columnIndex": 0,
+  "value": "3.5",
+  "tolerance": 5.0
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `rowIndex` | `Integer` | 是 | 行索引（从 0 开始） |
+| `columnIndex` | `Integer` | 是 | 列索引（从 0 开始） |
+| `value` | `String` | 是 | 正确答案值 |
+| `tolerance` | `Double` | 否 | 单元格级误差百分比（如 `5` 表示 ±5%），优先级最高 |
+
+### 2.4 ColumnTolerance 对象格式
+
+教师设置列级误差时使用：
+
+```json
+{
+  "columnIndex": 0,
+  "tolerance": 3.0
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `columnIndex` | `Integer` | 是 | 列索引（从 0 开始） |
+| `tolerance` | `Double` | 是 | 列级误差百分比（如 `3` 表示 ±3%） |
+
+### 2.5 教师创建完整请求示例
+
+```json
+{
+  "dataType": 2,
+  "tableRowHeaders": ["实验1", "实验2"],
+  "tableColumnHeaders": ["温度", "湿度", "压力"],
+  "tableCellAnswers": [
+    {"rowIndex": 0, "columnIndex": 0, "value": "3.5"},
+    {"rowIndex": 0, "columnIndex": 1, "value": "60", "tolerance": 10.0},
+    {"rowIndex": 0, "columnIndex": 2, "value": "101.3"},
+    {"rowIndex": 1, "columnIndex": 0, "value": "4.2"},
+    {"rowIndex": 1, "columnIndex": 1, "value": "55"},
+    {"rowIndex": 1, "columnIndex": 2, "value": "102.1"}
+  ],
+  "tableColumnTolerances": [
+    {"columnIndex": 0, "tolerance": 5.0},
+    {"columnIndex": 2, "tolerance": 3.0}
+  ],
+  "tolerance": 10.0
+}
+```
+
+---
+
+## 三、数据库存储格式
+
+### 3.1 `data_collection.remark`（表格结构描述 + 误差配置）
+
+```json
+{
+  "tableRowHeaders": ["实验1", "实验2"],
+  "tableColumnHeaders": ["温度", "湿度", "压力"],
+  "tableCellAnswers": [
+    {"rowIndex": 0, "columnIndex": 0, "value": "3.5"},
+    {"rowIndex": 0, "columnIndex": 1, "value": "60", "tolerance": 10.0},
+    {"rowIndex": 0, "columnIndex": 2, "value": "101.3"},
+    {"rowIndex": 1, "columnIndex": 0, "value": "4.2"},
+    {"rowIndex": 1, "columnIndex": 1, "value": "55"},
+    {"rowIndex": 1, "columnIndex": 2, "value": "102.1"}
+  ],
+  "columnTolerances": [
+    {"columnIndex": 0, "tolerance": 5.0},
+    {"columnIndex": 2, "tolerance": 3.0}
+  ]
+}
+```
+
+### 3.2 `data_collection.correct_answer`（正确答案 Map）
+
+key 为 `"rowIndex-columnIndex"` 格式字符串，value 为答案值：
+
+```json
+{
+  "0-0": "3.5",
+  "0-1": "60",
+  "0-2": "101.3",
+  "1-0": "4.2",
+  "1-1": "55",
+  "1-2": "102.1"
+}
+```
+
+### 3.3 `data_collection.tolerance`（步骤级误差）
+
+独立列存储，类型 `Double`，如 `10.0` 表示 ±10%。作为兜底误差，仅在没有单元格级和列级误差时使用。
+
+---
+
+## 四、学生端 — 填写表格数值
+
+### 4.1 接口说明
+
+| 操作 | 接口 | 方法 |
+|---|---|---|
+| 提交 | `/api/student/procedure-submissions/data-collection/complete` | POST |
+| 修改 | `/api/student/procedure-submissions/data-collection/update` | PUT |
+
+### 4.2 学生提交参数
+
+学生通过 `@RequestParam` 传入 `tableCellAnswers` 参数（JSON 字符串），格式为 **Map**：
+
+```
+tableCellAnswers: {"0-0":"3.5","0-1":"58","0-2":"101.0","1-0":"4.0","1-1":"56","1-2":"103.2"}
+```
+
+| 规则 | 说明 |
+|---|---|
+| key 格式 | `"rowIndex-columnIndex"`，如 `"0-0"`, `"1-2"` |
+| value 格式 | 答案值字符串 |
+| 必须覆盖所有单元格 | 学生必须填写表格中所有单元格 |
+
+### 4.3 学生答案存储格式
+
+学生答案存入 `student_experimental_procedure.answer` 列：
+
+```json
+{
+  "type": "DATA_COLLECTION",
+  "data": {
+    "tableCellAnswers": {
+      "0-0": "3.5",
+      "0-1": "58",
+      "0-2": "101.0",
+      "1-0": "4.0",
+      "1-1": "56",
+      "1-2": "103.2"
+    }
+  }
+}
+```
+
+---
+
+## 五、自动判分 — 误差优先级
+
+自动判分时，对每个单元格按以下优先级查找误差配置：
+
+```
+单元格级（tableCellAnswers[i].tolerance） > 列级（columnTolerances） > 步骤级（tolerance 列）
+```
+
+| 级别 | 来源 | key 格式 | 示例 |
+|---|---|---|---|
+| **单元格级** | `remark.tableCellAnswers[i].tolerance` | `"rowIndex-columnIndex"` | `"0-1"` → `10.0` |
+| **列级** | `remark.columnTolerances[i].tolerance` | `columnIndex` 字符串 | `"0"` → `5.0` |
+| **步骤级** | `data_collection.tolerance` 列 | 无 | `10.0` |
+
+### 判分公式
+
+对于数值类型答案，使用**百分比相对误差**：
+
+```
+|学生答案 - 正确答案| / |正确答案| ≤ 误差 / 100
+```
+
+- 误差为 `null` 或 `0` 时，执行精确匹配
+- 正确答案为 `0` 时，执行精确匹配（避免除零）
+- 非数值类型答案执行字符串精确匹配
+
+### 判分流程
+
+1. 从 `correct_answer` 列解析出 `Map<"rowIndex-columnIndex", 正确答案>`
+2. 从 `remark` 列解析出单元格级误差 `Map<"rowIndex-columnIndex", 误差>` 和列级误差 `Map<"columnIndex", 误差>`
+3. 遍历每个正确答案条目：
+   - 查找单元格级误差 → 未配置则查找列级误差 → 未配置则使用步骤级误差
+   - 比对学生答案与正确答案
+4. 计算得分 = 正确数 / 总数 × 100（百分比制，保留两位小数）
+
+---
+
+## 六、响应格式 — 查询回显
+
+### 6.1 教师查询步骤详情（未提交时）
+
+返回 `tableRemark` 字段，包含表格结构描述：
+
+```json
+{
+  "dataCollectionType": 2,
+  "tableRemark": {
+    "tableRowHeaders": ["实验1", "实验2"],
+    "tableColumnHeaders": ["温度", "湿度", "压力"],
+    "tableCellAnswers": [
+      {"rowIndex": 0, "columnIndex": 0, "value": "3.5"},
+      {"rowIndex": 0, "columnIndex": 1, "value": "60", "tolerance": 10.0}
+    ],
+    "columnTolerances": [
+      {"columnIndex": 0, "tolerance": 5.0}
+    ]
+  },
+  "tolerance": 10.0
+}
+```
+
+### 6.2 教师/学生查询已提交详情
+
+返回学生填写的 `tableCellAnswers` 列表（从 `answer` JSON 解析）：
+
+```json
+{
+  "tableCellAnswers": [
+    {"rowIndex": 0, "columnIndex": 0, "value": "3.5"},
+    {"rowIndex": 0, "columnIndex": 1, "value": "58"},
+    {"rowIndex": 1, "columnIndex": 0, "value": "4.0"}
+  ]
+}
+```
+
+---
+
+## 七、格式速查表
+
+| 场景 | 格式 | key 定位方式 |
+|---|---|---|
+| 教师设置单元格答案 | `List<TableCellAnswer>` | `rowIndex` + `columnIndex` 两个整型字段 |
+| 教师设置列级误差 | `List<ColumnTolerance>` | `columnIndex` 整型字段 |
+| remark 存储 | `TableRemarkDTO` (JSON) | 同上 |
+| correct_answer 存储 | `Map<"rowIndex-columnIndex", 答案>` | 拼接字符串 key，如 `"0-1"` |
+| 学生提交答案 | `Map<"rowIndex-columnIndex", 答案>` | 拼接字符串 key，如 `"0-1"` |
+| 学生答案存储 | `Map<"rowIndex-columnIndex", 答案>` | 同上 |
+| 响应回显 | `List<TableCellAnswer>` | `rowIndex` + `columnIndex` 两个整型字段 |
+| 自动判分 — 单元格误差查找 | `Map<"rowIndex-columnIndex", 误差>` | 拼接字符串 key |
+| 自动判分 — 列级误差查找 | `Map<"columnIndex", 误差>` | 列索引字符串，如 `"0"` |
+
+---
+
+## 八、禁止事项
+
+1. **禁止**使用 `"A1"`, `"B2"` 等字母+数字组合定位单元格，统一使用 `rowIndex` + `columnIndex` 整型字段
+2. **禁止**在 `correct_answer` 列中使用非 `"rowIndex-columnIndex"` 格式的 key
+3. **禁止**学生提交时使用非 `"rowIndex-columnIndex"` 格式的 key
+4. **禁止**在 `remark` JSON 中存储 `dataType`、`correctAnswer`、`tolerance` 等冗余字段
+5. **禁止**跳过单元格——`tableCellAnswers` 必须覆盖表格所有行列组合

--- a/src/main/java/com/example/demo/pojo/dto/mapvo/ColumnTolerance.java
+++ b/src/main/java/com/example/demo/pojo/dto/mapvo/ColumnTolerance.java
@@ -1,0 +1,63 @@
+package com.example.demo.pojo.dto.mapvo;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 表格列级误差
+ * 用于替代 Map<String, Double> 结构（列级误差映射）
+ * Key: 列名，Value: 误差百分比
+ */
+@Data
+public class ColumnTolerance {
+
+    /**
+     * 列名（如 "A"、"B"）
+     */
+    private String columnName;
+
+    /**
+     * 列级误差百分比（单位：%）
+     * 示例：5 表示允许±5%的相对误差
+     */
+    private Double tolerance;
+
+    /**
+     * 将 List<ColumnTolerance> 转换为 Map<String, Double>
+     *
+     * @param list 列级误差列表
+     * @return Map<列名, 误差百分比>
+     */
+    public static Map<String, Double> toMap(List<ColumnTolerance> list) {
+        if (list == null || list.isEmpty()) {
+            return Map.of();
+        }
+        return list.stream()
+                .filter(ct -> ct.getTolerance() != null)
+                .collect(Collectors.toMap(ColumnTolerance::getColumnName, ColumnTolerance::getTolerance));
+    }
+
+    /**
+     * 将 Map<String, Double> 转换为 List<ColumnTolerance>
+     *
+     * @param map Map<列名, 误差百分比>
+     * @return 列级误差列表
+     */
+    public static List<ColumnTolerance> fromMap(Map<String, Double> map) {
+        if (map == null || map.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return map.entrySet().stream()
+                .map(entry -> {
+                    ColumnTolerance ct = new ColumnTolerance();
+                    ct.setColumnName(entry.getKey());
+                    ct.setTolerance(entry.getValue());
+                    return ct;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/demo/pojo/dto/mapvo/ColumnTolerance.java
+++ b/src/main/java/com/example/demo/pojo/dto/mapvo/ColumnTolerance.java
@@ -9,28 +9,20 @@ import java.util.stream.Collectors;
 
 /**
  * 表格列级误差
- * 用于替代 Map<String, Double> 结构（列级误差映射）
- * Key: 列名，Value: 误差百分比
+ * 使用 columnIndex 定位列（从 0 开始，对应 tableColumnHeaders 数组下标）
  */
 @Data
 public class ColumnTolerance {
 
-    /**
-     * 列名（如 "A"、"B"）
-     */
-    private String columnName;
+    /** 列索引（从 0 开始，对应 tableColumnHeaders 数组下标） */
+    private Integer columnIndex;
 
-    /**
-     * 列级误差百分比（单位：%）
-     * 示例：5 表示允许±5%的相对误差
-     */
+    /** 列级误差百分比（单位：%），示例：5 表示允许±5%的相对误差 */
     private Double tolerance;
 
     /**
      * 将 List<ColumnTolerance> 转换为 Map<String, Double>
-     *
-     * @param list 列级误差列表
-     * @return Map<列名, 误差百分比>
+     * key 格式: 列索引字符串（如 "0", "1"）
      */
     public static Map<String, Double> toMap(List<ColumnTolerance> list) {
         if (list == null || list.isEmpty()) {
@@ -38,14 +30,12 @@ public class ColumnTolerance {
         }
         return list.stream()
                 .filter(ct -> ct.getTolerance() != null)
-                .collect(Collectors.toMap(ColumnTolerance::getColumnName, ColumnTolerance::getTolerance));
+                .collect(Collectors.toMap(ct -> String.valueOf(ct.getColumnIndex()), ColumnTolerance::getTolerance));
     }
 
     /**
      * 将 Map<String, Double> 转换为 List<ColumnTolerance>
-     *
-     * @param map Map<列名, 误差百分比>
-     * @return 列级误差列表
+     * key 格式: 列索引字符串（如 "0", "1"）
      */
     public static List<ColumnTolerance> fromMap(Map<String, Double> map) {
         if (map == null || map.isEmpty()) {
@@ -54,7 +44,7 @@ public class ColumnTolerance {
         return map.entrySet().stream()
                 .map(entry -> {
                     ColumnTolerance ct = new ColumnTolerance();
-                    ct.setColumnName(entry.getKey());
+                    ct.setColumnIndex(Integer.parseInt(entry.getKey()));
                     ct.setTolerance(entry.getValue());
                     return ct;
                 })

--- a/src/main/java/com/example/demo/pojo/dto/mapvo/TableCellAnswer.java
+++ b/src/main/java/com/example/demo/pojo/dto/mapvo/TableCellAnswer.java
@@ -9,47 +9,45 @@ import java.util.stream.Collectors;
 
 /**
  * 表格单元格答案
- * 用于替代 Map<String, String> 结构（表格答案）
- * Key: 单元格位置，Value: 答案值
+ * 使用 rowIndex + columnIndex 定位单元格（从 0 开始）
  */
 @Data
 public class TableCellAnswer {
 
-    /**
-     * 单元格位置（如 A1, B2）
-     */
-    private String cellPosition;
+    /** 行索引（从 0 开始，对应 tableRowHeaders 数组下标） */
+    private Integer rowIndex;
 
-    /**
-     * 答案值
-     */
+    /** 列索引（从 0 开始，对应 tableColumnHeaders 数组下标） */
+    private Integer columnIndex;
+
+    /** 答案值 */
     private String value;
 
-    /**
-     * 单元格级误差百分比（可选，覆盖步骤级误差，单位：%）
-     * 示例：5 表示允许±5%的相对误差
-     */
+    /** 单元格级误差百分比（可选，覆盖列级和步骤级误差，单位：%） */
     private Double tolerance;
 
     /**
+     * 获取位置标识 key（格式: "rowIndex-columnIndex"，如 "0-0"）
+     */
+    public String getPositionKey() {
+        return rowIndex + "-" + columnIndex;
+    }
+
+    /**
      * 将 List<TableCellAnswer> 转换为 Map<String, String>
-     *
-     * @param answers 答案列表
-     * @return Map<单元格位置, 答案值>
+     * key 格式: "rowIndex-columnIndex"
      */
     public static Map<String, String> toMap(List<TableCellAnswer> answers) {
         if (answers == null || answers.isEmpty()) {
             return Map.of();
         }
         return answers.stream()
-                .collect(Collectors.toMap(TableCellAnswer::getCellPosition, TableCellAnswer::getValue));
+                .collect(Collectors.toMap(TableCellAnswer::getPositionKey, TableCellAnswer::getValue));
     }
 
     /**
      * 将 List<TableCellAnswer> 转换为 Map<String, Double>（单元格级误差映射）
-     *
-     * @param answers 答案列表
-     * @return Map<单元格位置, 误差百分比>
+     * key 格式: "rowIndex-columnIndex"
      */
     public static Map<String, Double> toToleranceMap(List<TableCellAnswer> answers) {
         if (answers == null || answers.isEmpty()) {
@@ -57,14 +55,12 @@ public class TableCellAnswer {
         }
         return answers.stream()
                 .filter(answer -> answer.getTolerance() != null)
-                .collect(Collectors.toMap(TableCellAnswer::getCellPosition, TableCellAnswer::getTolerance));
+                .collect(Collectors.toMap(TableCellAnswer::getPositionKey, TableCellAnswer::getTolerance));
     }
 
     /**
      * 将 Map<String, String> 转换为 List<TableCellAnswer>
-     *
-     * @param map Map<单元格位置, 答案值>
-     * @return 答案列表
+     * key 格式: "rowIndex-columnIndex"
      */
     public static List<TableCellAnswer> fromMap(Map<String, String> map) {
         return fromMap(map, null);
@@ -72,10 +68,7 @@ public class TableCellAnswer {
 
     /**
      * 将 Map<String, String> 和误差映射转换为 List<TableCellAnswer>
-     *
-     * @param map Map<单元格位置, 答案值>
-     * @param toleranceMap Map<单元格位置, 误差百分比>
-     * @return 答案列表
+     * key 格式: "rowIndex-columnIndex"
      */
     public static List<TableCellAnswer> fromMap(Map<String, String> map, Map<String, Double> toleranceMap) {
         if (map == null || map.isEmpty()) {
@@ -84,7 +77,9 @@ public class TableCellAnswer {
         return map.entrySet().stream()
                 .map(entry -> {
                     TableCellAnswer answer = new TableCellAnswer();
-                    answer.setCellPosition(entry.getKey());
+                    String[] parts = entry.getKey().split("-");
+                    answer.setRowIndex(Integer.parseInt(parts[0]));
+                    answer.setColumnIndex(Integer.parseInt(parts[1]));
                     answer.setValue(entry.getValue());
                     if (toleranceMap != null) {
                         answer.setTolerance(toleranceMap.get(entry.getKey()));

--- a/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
@@ -1,0 +1,30 @@
+package com.example.demo.pojo.dto.remark;
+
+import com.example.demo.pojo.dto.mapvo.DataField;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 填空类型 remark DTO
+ * 用于序列化/反序列化 data_collection.remark 中的填空类型 JSON
+ *
+ * JSON 格式：
+ * {"fillBlanks":[{"fieldName":"Uab","value":"","tolerance":5.0}]}
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FillBlankRemarkDTO {
+
+    /** 填空数据列表（字段名 + 值 + 误差） */
+    private List<DataField> fillBlanks;
+}

--- a/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
@@ -1,0 +1,42 @@
+package com.example.demo.pojo.dto.remark;
+
+import com.example.demo.pojo.dto.mapvo.ColumnTolerance;
+import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 表格类型 remark DTO
+ * 用于序列化/反序列化 data_collection.remark 中的表格类型 JSON
+ *
+ * JSON 格式：
+ * {"tableRowHeaders":["A"],"tableColumnHeaders":["1"],
+ *  "tableCellAnswers":[{"cellPosition":"A1","value":"3.5","tolerance":5.0}],
+ *  "columnTolerances":[{"columnName":"A","tolerance":3.0}]}
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TableRemarkDTO {
+
+    /** 表格行表头 */
+    private List<String> tableRowHeaders;
+
+    /** 表格列表头 */
+    private List<String> tableColumnHeaders;
+
+    /** 表格单元格答案列表（坐标 + 值 + 误差） */
+    private List<TableCellAnswer> tableCellAnswers;
+
+    /** 列级误差列表（列名 + 误差百分比） */
+    private List<ColumnTolerance> columnTolerances;
+}

--- a/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/TableRemarkDTO.java
@@ -16,9 +16,11 @@ import java.util.List;
  * 用于序列化/反序列化 data_collection.remark 中的表格类型 JSON
  *
  * JSON 格式：
- * {"tableRowHeaders":["A"],"tableColumnHeaders":["1"],
- *  "tableCellAnswers":[{"cellPosition":"A1","value":"3.5","tolerance":5.0}],
- *  "columnTolerances":[{"columnName":"A","tolerance":3.0}]}
+ * {"tableRowHeaders":["A","B"],"tableColumnHeaders":["1","2"],
+ *  "tableCellAnswers":[{"rowIndex":0,"columnIndex":0,"value":"3.5","tolerance":5.0}],
+ *  "columnTolerances":[{"columnIndex":0,"tolerance":3.0}]}
+ *
+ * rowIndex/columnIndex 从 0 开始，与 tableRowHeaders/tableColumnHeaders 数组索引对应
  */
 @Data
 @Builder
@@ -34,9 +36,9 @@ public class TableRemarkDTO {
     /** 表格列表头 */
     private List<String> tableColumnHeaders;
 
-    /** 表格单元格答案列表（坐标 + 值 + 误差） */
+    /** 表格单元格答案列表（行索引 + 列索引 + 值 + 误差） */
     private List<TableCellAnswer> tableCellAnswers;
 
-    /** 列级误差列表（列名 + 误差百分比） */
+    /** 列级误差列表（列索引 + 误差百分比） */
     private List<ColumnTolerance> columnTolerances;
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
@@ -1,11 +1,11 @@
 package com.example.demo.pojo.request.teacher;
 
+import com.example.demo.pojo.dto.mapvo.ColumnTolerance;
 import com.example.demo.pojo.dto.mapvo.DataField;
 import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * 创建数据收集步骤请求
@@ -40,8 +40,8 @@ public class CreateDataCollectionProcedureRequest {
     /** 表格单元格答案列表，当dataType=2时使用，只对数字类型单元格进行自动判分。每个单元格可单独配置tolerance属性（百分比，单位：%），优先级最高 */
     private List<TableCellAnswer> tableCellAnswers;
 
-    /** 表格列级误差映射（可选，列名→误差百分比，单位：%），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
-    private Map<String, Double> tableColumnTolerances;
+    /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
+    private List<ColumnTolerance> tableColumnTolerances;
 
     /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
     private Double tolerance;

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
@@ -1,11 +1,11 @@
 package com.example.demo.pojo.request.teacher;
 
+import com.example.demo.pojo.dto.mapvo.ColumnTolerance;
 import com.example.demo.pojo.dto.mapvo.DataField;
 import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * 插入数据收集步骤请求
@@ -43,8 +43,8 @@ public class InsertDataCollectionProcedureRequest {
     /** 表格单元格答案列表，当dataType=2时使用，只对数字类型单元格进行自动判分。每个单元格可单独配置tolerance属性（百分比，单位：%），优先级最高 */
     private List<TableCellAnswer> tableCellAnswers;
 
-    /** 表格列级误差映射（可选，列名→误差百分比，单位：%），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
-    private Map<String, Double> tableColumnTolerances;
+    /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
+    private List<ColumnTolerance> tableColumnTolerances;
 
     /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
     private Double tolerance;

--- a/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
@@ -1,11 +1,11 @@
 package com.example.demo.pojo.request.teacher;
 
+import com.example.demo.pojo.dto.mapvo.ColumnTolerance;
 import com.example.demo.pojo.dto.mapvo.DataField;
 import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * 修改数据收集步骤请求
@@ -40,8 +40,8 @@ public class UpdateDataCollectionProcedureRequest {
     /** 表格单元格答案列表，当dataType=2时使用，只对数字类型单元格进行自动判分。每个单元格可单独配置tolerance属性（百分比，单位：%），优先级最高 */
     private List<TableCellAnswer> tableCellAnswers;
 
-    /** 表格列级误差映射（可选，列名→误差百分比，单位：%），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
-    private Map<String, Double> tableColumnTolerances;
+    /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
+    private List<ColumnTolerance> tableColumnTolerances;
 
     /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
     private Double tolerance;

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -411,15 +411,15 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             // 判断表格类型答案
             if (tableCellAnswers != null && !tableCellAnswers.isEmpty()) {
                 for (java.util.Map.Entry<String, String> entry : correctAnswers.entrySet()) {
-                    String cellPosition = entry.getKey();
-                    String studentAnswer = tableCellAnswers.get(cellPosition);
+                    String positionKey = entry.getKey(); // 格式: "rowIndex-columnIndex"，如 "0-0"
+                    String studentAnswer = tableCellAnswers.get(positionKey);
 
                     // 误差优先级：单元格级 > 列级 > 步骤级
-                    Double finalTolerance = cellTolerances.get(cellPosition);
+                    Double finalTolerance = cellTolerances.get(positionKey);
                     if (finalTolerance == null) {
-                        // 解析单元格位置的列名（如A1→A，B2→B）
-                        String columnName = cellPosition.replaceAll("\\d", "");
-                        finalTolerance = columnTolerances.get(columnName);
+                        // 从位置 key 中提取列索引（如 "0-1" → "1"）
+                        String columnIndex = positionKey.split("-")[1];
+                        finalTolerance = columnTolerances.get(columnIndex);
                         if (finalTolerance == null) {
                             finalTolerance = stepTolerance;
                         }

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -34,8 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +52,6 @@ public class TeacherProcedureCreationService {
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
     private final TopicMapper topicMapper;
-    private final ObjectMapper objectMapper;
 
     /**
      * 获取实验的最大步骤号
@@ -181,24 +178,22 @@ public class TeacherProcedureCreationService {
         // 2. 构建数据描述和正确答案JSON（包含误差配置）
         Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
         Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-        Map<String, Double> fieldTolerances = DataField.toToleranceMap(request.getDataFields());
-        Map<String, Double> cellTolerances = TableCellAnswer.toToleranceMap(request.getTableCellAnswers());
 
         String remark;
         String correctAnswer;
         if (request.getDataType() == 1) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                    dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                    request.getDataFields());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
-                    request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                    tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                    request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
+                    request.getTableColumnTolerances());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
         } else {
-            remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                    request.getTableRowHeaders(), request.getTableColumnHeaders());
-            correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+            // 文件上传类型（type=3）：remark 无额外数据
+            remark = "{}";
+            correctAnswer = null;
         }
 
         // 3. 创建数据收集记录
@@ -426,24 +421,22 @@ public class TeacherProcedureCreationService {
                 // 构建数据描述和正确答案JSON（包含误差配置）
                 Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
                 Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-                Map<String, Double> fieldTolerances = DataField.toToleranceMap(request.getDataFields());
-                Map<String, Double> cellTolerances = TableCellAnswer.toToleranceMap(request.getTableCellAnswers());
 
                 String remark;
                 String correctAnswer;
                 if (request.getDataType() == 1) {
                     remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                            dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                            request.getDataFields());
                     correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
                 } else if (request.getDataType() == 2) {
                     remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
-                            request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                            tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                            request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
+                            request.getTableColumnTolerances());
                     correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
                 } else {
-                    remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                            request.getTableRowHeaders(), request.getTableColumnHeaders());
-                    correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+                    // 文件上传类型（type=3）：remark 无额外数据
+                    remark = "{}";
+                    correctAnswer = null;
                 }
 
                 dataCollection.setRemark(remark);
@@ -693,24 +686,22 @@ public class TeacherProcedureCreationService {
         // 构建数据描述和正确答案JSON（包含误差配置）
         Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
         Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-        Map<String, Double> fieldTolerances = DataField.toToleranceMap(request.getDataFields());
-        Map<String, Double> cellTolerances = TableCellAnswer.toToleranceMap(request.getTableCellAnswers());
 
         String remark;
         String correctAnswer;
         if (request.getDataType() == 1) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
-                    dataFieldsMap, dataFieldsMap, request.getTolerance(), fieldTolerances);
+                    request.getDataFields());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
-                    request.getTableRowHeaders(), request.getTableColumnHeaders(), tableCellAnswersMap,
-                    tableCellAnswersMap, request.getTolerance(), cellTolerances, request.getTableColumnTolerances());
+                    request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
+                    request.getTableColumnTolerances());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(tableCellAnswersMap);
         } else {
-            remark = buildDataCollectionRemark(request.getDataType(), dataFieldsMap,
-                    request.getTableRowHeaders(), request.getTableColumnHeaders());
-            correctAnswer = buildCorrectAnswerJson(request.getDataType(), dataFieldsMap, tableCellAnswersMap);
+            // 文件上传类型（type=3）：remark 无额外数据
+            remark = "{}";
+            correctAnswer = null;
         }
 
         // 创建数据收集记录
@@ -867,53 +858,6 @@ public class TeacherProcedureCreationService {
         }
         if (startTime.isAfter(endTime)) {
             throw new com.example.demo.exception.BusinessException(400, "开始时间不能晚于结束时间");
-        }
-    }
-
-    /**
-     * 构建数据收集的remark（数据描述JSON）
-     */
-    private String buildDataCollectionRemark(Integer dataType,
-                                             Map<String, String> dataFields,
-                                             List<String> tableRowHeaders,
-                                             List<String> tableColumnHeaders) {
-        try {
-            Map<String, Object> remarkData = new HashMap<>();
-
-            if (dataType == 1) {
-                // 填空类型：保存数据字段名称列表
-                remarkData.put("dataFields", dataFields != null ? dataFields.keySet() : List.of());
-            } else if (dataType == 2) {
-                // 表格类型：保存表格���构
-                remarkData.put("tableRowHeaders", tableRowHeaders);
-                remarkData.put("tableColumnHeaders", tableColumnHeaders);
-            }
-
-            return objectMapper.writeValueAsString(remarkData);
-        } catch (Exception e) {
-            log.error("构建数据描述JSON失败", e);
-            throw new com.example.demo.exception.BusinessException(500, "构建数据描述失败");
-        }
-    }
-
-    /**
-     * 构建数据收集的correctAnswer（正确答案JSON）
-     */
-    private String buildCorrectAnswerJson(Integer dataType,
-                                          Map<String, String> dataFields,
-                                          Map<String, String> tableCellAnswers) {
-        try {
-            if (dataType == 1) {
-                // 填空类型：使用 dataFields 作为正确答案
-                return objectMapper.writeValueAsString(dataFields);
-            } else if (dataType == 2) {
-                // 表格类型：使用 tableCellAnswers 作为正确答案
-                return objectMapper.writeValueAsString(tableCellAnswers);
-            }
-            return null;
-        } catch (Exception e) {
-            log.error("构建正确答案JSON失败", e);
-            throw new com.example.demo.exception.BusinessException(500, "构建正确答案失败");
         }
     }
 

--- a/src/main/java/com/example/demo/util/AnswerMapJSONUntil.java
+++ b/src/main/java/com/example/demo/util/AnswerMapJSONUntil.java
@@ -312,7 +312,7 @@ public class AnswerMapJSONUntil {
      * 将数据收集答案转换为答案 JSON 字符串
      *
      * @param fillBlankAnswers 填空答案 Map<字段名, 答案>
-     * @param tableCellAnswers 表格单元格答案 Map<单元格位置, 答案>
+     * @param tableCellAnswers 表格单元格答案 Map<位置key, 答案>（位置key格式: "rowIndex-columnIndex"）
      * @return JSON 字符串，转换失败返回 null
      */
     public static String toDataCollectionJson(Map<String, String> fillBlankAnswers,

--- a/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
+++ b/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
@@ -1,5 +1,10 @@
 package com.example.demo.util;
 
+import com.example.demo.pojo.dto.mapvo.ColumnTolerance;
+import com.example.demo.pojo.dto.mapvo.DataField;
+import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +14,16 @@ import java.util.Map;
 
 /**
  * 数据收集步骤数据转换工具类
- * 用于将结构化的填空和表格数据转换为JSON格式存储
+ * 用于将结构化的填空和表格数据转换为JSON格式存储到 remark 字段
+ *
+ * remark JSON 格式（按数据类型区分）：
+ * - 填空类型（type=1）：{"fillBlanks":[{"fieldName":"Uab","value":"","tolerance":5.0}]}
+ * - 表格类型（type=2）：{"tableRowHeaders":["A"],"tableColumnHeaders":["1"],
+ *   "tableCellAnswers":[{"cellPosition":"A1","value":"3.5","tolerance":5.0}],
+ *   "columnTolerances":[{"columnName":"A","tolerance":3.0}]}
+ * - 文件类型（type=3）：{}
+ *
+ * 注意：dataType 已从 remark 中移除，请通过 DataCollection.type 获取数据类型
  */
 @Slf4j
 public class DataCollectionDataUtil {
@@ -17,106 +31,17 @@ public class DataCollectionDataUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
-     * 数据收集数据结构
-     */
-    public static class DataCollectionData {
-        /** 数据类型（1-填空，2-表格） */
-        private Integer dataType;
-
-        /** 填空数据（Map<需要的数据, 数据答案>） */
-        private Map<String, String> fillBlanks;
-
-        /** 表格行表头 */
-        private List<String> tableRowHeaders;
-
-        /** 表格列表头 */
-        private List<String> tableColumnHeaders;
-
-        /** 表格单元格答案（Map<表格坐标, 答案>） */
-        private Map<String, String> tableCellAnswers;
-
-        public Integer getDataType() {
-            return dataType;
-        }
-
-        public void setDataType(Integer dataType) {
-            this.dataType = dataType;
-        }
-
-        public Map<String, String> getFillBlanks() {
-            return fillBlanks;
-        }
-
-        public void setFillBlanks(Map<String, String> fillBlanks) {
-            this.fillBlanks = fillBlanks;
-        }
-
-        public List<String> getTableRowHeaders() {
-            return tableRowHeaders;
-        }
-
-        public void setTableRowHeaders(List<String> tableRowHeaders) {
-            this.tableRowHeaders = tableRowHeaders;
-        }
-
-        public List<String> getTableColumnHeaders() {
-            return tableColumnHeaders;
-        }
-
-        public void setTableColumnHeaders(List<String> tableColumnHeaders) {
-            this.tableColumnHeaders = tableColumnHeaders;
-        }
-
-        public Map<String, String> getTableCellAnswers() {
-            return tableCellAnswers;
-        }
-
-        public void setTableCellAnswers(Map<String, String> tableCellAnswers) {
-            this.tableCellAnswers = tableCellAnswers;
-        }
-    }
-
-    /**
      * 将填空类型数据转换为JSON
      *
-     * @param fillBlanks 填空数据
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
+     * @param dataFields 填空数据列表（fieldName + value + tolerance）
      * @return JSON字符串
      */
-    public static String convertFillBlanksToJson(Map<String, String> fillBlanks,
-                                                  Map<String, String> correctAnswer,
-                                                  Double tolerance) {
-        return convertFillBlanksToJson(fillBlanks, correctAnswer, tolerance, null);
-    }
-
-    /**
-     * 将填空类型数据转换为JSON（支持字段级误差）
-     *
-     * @param fillBlanks 填空数据
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param fieldTolerances 字段级误差映射
-     * @return JSON字符串
-     */
-    public static String convertFillBlanksToJson(Map<String, String> fillBlanks,
-                                                  Map<String, String> correctAnswer,
-                                                  Double tolerance,
-                                                  Map<String, Double> fieldTolerances) {
-        DataCollectionData data = new DataCollectionData();
-        data.setDataType(1);
-        data.setFillBlanks(fillBlanks);
-
+    public static String convertFillBlanksToJson(List<DataField> dataFields) {
         try {
-            // 将正确答案和误差也存储到同一个JSON中
-            Map<String, Object> result = new java.util.HashMap<>();
-            result.put("dataType", 1);
-            result.put("fillBlanks", fillBlanks);
-            result.put("correctAnswer", correctAnswer);
-            result.put("tolerance", tolerance);
-            result.put("fieldTolerances", fieldTolerances);
-
-            return objectMapper.writeValueAsString(result);
+            FillBlankRemarkDTO dto = FillBlankRemarkDTO.builder()
+                    .fillBlanks(dataFields)
+                    .build();
+            return objectMapper.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
             log.error("转换填空数据为JSON失败", e);
             throw new RuntimeException("转换填空数据为JSON失败", e);
@@ -124,74 +49,26 @@ public class DataCollectionDataUtil {
     }
 
     /**
-     * 将表格类型数据转换为JSON
-     *
-     * @param tableRowHeaders 表格行表头
-     * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @return JSON字符串
-     */
-    public static String convertTableToJson(List<String> tableRowHeaders,
-                                           List<String> tableColumnHeaders,
-                                           Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance) {
-        return convertTableToJson(tableRowHeaders, tableColumnHeaders, tableCellAnswers, correctAnswer, tolerance, null);
-    }
-
-    /**
-     * 将表格类型数据转换为JSON（支持单元格级误差）
-     *
-     * @param tableRowHeaders 表格行表头
-     * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param cellTolerances 单元格级误差映射
-     * @return JSON字符串
-     */
-    public static String convertTableToJson(List<String> tableRowHeaders,
-                                           List<String> tableColumnHeaders,
-                                           Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance,
-                                           Map<String, Double> cellTolerances) {
-        return convertTableToJson(tableRowHeaders, tableColumnHeaders, tableCellAnswers, correctAnswer, tolerance, cellTolerances, null);
-    }
-
-    /**
      * 将表格类型数据转换为JSON（支持单元格级和列级误差）
      *
-     * @param tableRowHeaders 表格行表头
+     * @param tableRowHeaders    表格行表头
      * @param tableColumnHeaders 表格列表头
-     * @param tableCellAnswers 表格单元格答案
-     * @param correctAnswer 正确答案
-     * @param tolerance 步骤级误差百分比（单位：%）
-     * @param cellTolerances 单元格级误差映射
-     * @param columnTolerances 列级误差映射
+     * @param tableCellAnswers   表格单元格答案列表（cellPosition + value + tolerance）
+     * @param columnTolerances   列级误差列表（columnName + tolerance，可选）
      * @return JSON字符串
      */
     public static String convertTableToJson(List<String> tableRowHeaders,
                                            List<String> tableColumnHeaders,
-                                           Map<String, String> tableCellAnswers,
-                                           Map<String, String> correctAnswer,
-                                           Double tolerance,
-                                           Map<String, Double> cellTolerances,
-                                           Map<String, Double> columnTolerances) {
+                                           List<TableCellAnswer> tableCellAnswers,
+                                           List<ColumnTolerance> columnTolerances) {
         try {
-            Map<String, Object> result = new java.util.HashMap<>();
-            result.put("dataType", 2);
-            result.put("tableRowHeaders", tableRowHeaders);
-            result.put("tableColumnHeaders", tableColumnHeaders);
-            result.put("tableCellAnswers", tableCellAnswers);
-            result.put("correctAnswer", correctAnswer);
-            result.put("tolerance", tolerance);
-            result.put("cellTolerances", cellTolerances);
-            result.put("columnTolerances", columnTolerances);
-
-            return objectMapper.writeValueAsString(result);
+            TableRemarkDTO dto = TableRemarkDTO.builder()
+                    .tableRowHeaders(tableRowHeaders)
+                    .tableColumnHeaders(tableColumnHeaders)
+                    .tableCellAnswers(tableCellAnswers)
+                    .columnTolerances(columnTolerances)
+                    .build();
+            return objectMapper.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
             log.error("转换表格数据为JSON失败", e);
             throw new RuntimeException("转换表格数据为JSON失败", e);
@@ -214,24 +91,47 @@ public class DataCollectionDataUtil {
     }
 
     /**
+     * 从 remark JSON 中解析为填空类型 DTO
+     *
+     * @param remarkJson remark JSON字符串
+     * @return 填空类型 DTO，解析失败返回 null
+     */
+    public static FillBlankRemarkDTO parseFillBlankRemark(String remarkJson) {
+        try {
+            return objectMapper.readValue(remarkJson, FillBlankRemarkDTO.class);
+        } catch (JsonProcessingException e) {
+            log.error("解析填空类型 remark 失败", e);
+            return null;
+        }
+    }
+
+    /**
+     * 从 remark JSON 中解析为表格类型 DTO
+     *
+     * @param remarkJson remark JSON字符串
+     * @return 表格类型 DTO，解析失败返回 null
+     */
+    public static TableRemarkDTO parseTableRemark(String remarkJson) {
+        try {
+            return objectMapper.readValue(remarkJson, TableRemarkDTO.class);
+        } catch (JsonProcessingException e) {
+            log.error("解析表格类型 remark 失败", e);
+            return null;
+        }
+    }
+
+    /**
      * 从JSON中解析字段级误差映射
      *
      * @param json 数据收集JSON字符串
      * @return 字段级误差映射
      */
     public static Map<String, Double> parseFieldTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode fieldTolerancesNode = root.get("fieldTolerances");
-            if (fieldTolerancesNode == null || fieldTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(fieldTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析字段级误差失败", e);
+        FillBlankRemarkDTO dto = parseFillBlankRemark(json);
+        if (dto == null || dto.getFillBlanks() == null) {
             return Map.of();
         }
+        return DataField.toToleranceMap(dto.getFillBlanks());
     }
 
     /**
@@ -241,18 +141,11 @@ public class DataCollectionDataUtil {
      * @return 单元格级误差映射
      */
     public static Map<String, Double> parseCellTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode cellTolerancesNode = root.get("cellTolerances");
-            if (cellTolerancesNode == null || cellTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(cellTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析单元格级误差失败", e);
+        TableRemarkDTO dto = parseTableRemark(json);
+        if (dto == null || dto.getTableCellAnswers() == null) {
             return Map.of();
         }
+        return TableCellAnswer.toToleranceMap(dto.getTableCellAnswers());
     }
 
     /**
@@ -262,17 +155,10 @@ public class DataCollectionDataUtil {
      * @return 列级误差映射
      */
     public static Map<String, Double> parseColumnTolerancesFromJson(String json) {
-        try {
-            com.fasterxml.jackson.databind.JsonNode root = objectMapper.readTree(json);
-            com.fasterxml.jackson.databind.JsonNode columnTolerancesNode = root.get("columnTolerances");
-            if (columnTolerancesNode == null || columnTolerancesNode.isNull()) {
-                return Map.of();
-            }
-            return objectMapper.convertValue(columnTolerancesNode,
-                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, Double>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析列级误差失败", e);
+        TableRemarkDTO dto = parseTableRemark(json);
+        if (dto == null || dto.getColumnTolerances() == null) {
             return Map.of();
         }
+        return ColumnTolerance.toMap(dto.getColumnTolerances());
     }
 }

--- a/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
+++ b/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
@@ -18,9 +18,9 @@ import java.util.Map;
  *
  * remark JSON 格式（按数据类型区分）：
  * - 填空类型（type=1）：{"fillBlanks":[{"fieldName":"Uab","value":"","tolerance":5.0}]}
- * - 表格类型（type=2）：{"tableRowHeaders":["A"],"tableColumnHeaders":["1"],
- *   "tableCellAnswers":[{"cellPosition":"A1","value":"3.5","tolerance":5.0}],
- *   "columnTolerances":[{"columnName":"A","tolerance":3.0}]}
+ * - 表格类型（type=2）：{"tableRowHeaders":["A","B"],"tableColumnHeaders":["1","2"],
+ *   "tableCellAnswers":[{"rowIndex":0,"columnIndex":0,"value":"3.5","tolerance":5.0}],
+ *   "columnTolerances":[{"columnIndex":0,"tolerance":3.0}]}
  * - 文件类型（type=3）：{}
  *
  * 注意：dataType 已从 remark 中移除，请通过 DataCollection.type 获取数据类型

--- a/src/main/resources/sql/remove_datatype_from_remark_migration.sql
+++ b/src/main/resources/sql/remove_datatype_from_remark_migration.sql
@@ -1,0 +1,280 @@
+-- ============================================================
+-- 数据迁移：规范化 data_collection.remark JSON 格式
+-- 执行时间：待定
+-- 说明：
+--   1. 早期旧格式（如 id=1,2,3）：{"dataFields":["Uab","I1"]}
+--      → 迁移为 {"fillBlanks":[{"fieldName":"Uab","value":""},{"fieldName":"I1","value":""}]}
+--      （correct_answer 列已存储正确答案，remark 中仅保留字段名）
+--
+--   2. 含冗余字段的新格式（如 id=7,9）：
+--      {"fillBlanks":{"Uab":"220"},"dataType":1,"correctAnswer":{"Uab":"220"},"tolerance":5}
+--      → 移除 dataType、correctAnswer、tolerance 冗余字段
+--      → fillBlanks 从 Map 转为 List 格式：
+--      {"fillBlanks":[{"fieldName":"Uab","value":"220","tolerance":5}]}
+--
+--   3. 表格类型新格式（含 tableCellAnswers 为 Map + cellTolerances）：
+--      → tableCellAnswers 从 Map 合并为 List<TableCellAnswer> 格式
+--      → columnTolerances 从 Map 转为 List<ColumnTolerance> 格式
+--
+--   4. 空记录（如 id=4,5,6,8）：type=3 文件上传，remark='{}'
+--      → 无需处理
+-- ============================================================
+
+-- ============================================================
+-- 第一部分：迁移前验证
+-- ============================================================
+
+-- 1. 查看所有 remark 数据
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != ''
+ORDER BY id;
+
+-- 2. 统计旧格式记录数（含 dataFields 但不含 fillBlanks）
+SELECT '旧格式(dataFields)记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 3. 统计含冗余字段的记录数（含 dataType 或 correctAnswer 或 tolerance）
+SELECT '含冗余字段记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- ============================================================
+-- 第二部分：备份数据（强烈建议）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS data_collection_remark_backup_20260415 AS
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != '';
+
+SELECT '备份行数' AS info, COUNT(*) AS total
+FROM data_collection_remark_backup_20260415;
+
+-- ============================================================
+-- 第三部分：迁移步骤一 — 旧格式 dataFields → fillBlanks (List 格式)
+-- ============================================================
+-- 将 {"dataFields":["Uab","I1","Us"]} 转为 {"fillBlanks":[{"fieldName":"Uab","value":""},{"fieldName":"I1","value":""},{"fieldName":"Us","value":""}]}
+-- 正确答案已存在于 correct_answer 列，remark 中仅保留字段名
+
+UPDATE data_collection
+SET remark = JSON_OBJECT(
+    'fillBlanks',
+    (
+        SELECT JSON_ARRAYAGG(JSON_OBJECT('fieldName', field, 'value', ''))
+        FROM JSON_TABLE(
+            JSON_EXTRACT(remark, '$.dataFields'),
+            '$[*]' COLUMNS (field VARCHAR(255) PATH '$')
+        ) AS jt
+    )
+)
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 验证步骤一
+SELECT '步骤一迁移后：旧格式剩余' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.dataFields')
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- ============================================================
+-- 第四部分：迁移步骤二 — 移除冗余字段 dataType/correctAnswer/tolerance
+-- ============================================================
+
+UPDATE data_collection
+SET remark = JSON_REMOVE(
+    JSON_REMOVE(
+        JSON_REMOVE(remark, '$.dataType'),
+        '$.correctAnswer'
+    ),
+    '$.tolerance'
+)
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- 验证步骤二
+SELECT '步骤二迁移后：仍含冗余字段的记录数' AS info, COUNT(*) AS total
+FROM data_collection
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND (
+    JSON_CONTAINS_PATH(remark, 'one', '$.dataType')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.correctAnswer')
+    OR JSON_CONTAINS_PATH(remark, 'one', '$.tolerance')
+  );
+
+-- ============================================================
+-- 第五部分：迁移步骤三 — fillBlanks 从 Map 格式转为 List 格式
+-- ============================================================
+-- 将 {"fillBlanks":{"Uab":"220","I1":"5"}} 转为
+--     {"fillBlanks":[{"fieldName":"Uab","value":"220"},{"fieldName":"I1","value":"5"}]}
+-- 此步骤处理那些已经是 Map 格式但需要转为 List 格式的记录
+
+UPDATE data_collection dc
+SET dc.remark = JSON_OBJECT(
+    'fillBlanks',
+    (
+        SELECT JSON_ARRAYAGG(JSON_OBJECT('fieldName', jt.k, 'value', jt.v))
+        FROM JSON_TABLE(
+            JSON_EXTRACT(dc.remark, '$.fillBlanks'),
+            '$[*]' COLUMNS (
+                k VARCHAR(255) PATH '$.key',
+                v VARCHAR(255) PATH '$.value'
+            )
+        ) AS jt
+    )
+)
+WHERE dc.remark IS NOT NULL
+  AND dc.remark != ''
+  AND dc.type = 1
+  AND JSON_CONTAINS_PATH(dc.remark, 'one', '$.fillBlanks')
+  AND JSON_TYPE(JSON_EXTRACT(dc.remark, '$.fillBlanks')) = 'OBJECT';
+
+-- 验证步骤三：检查填空类型是否还有 Map 格式的 fillBlanks
+SELECT id, type, JSON_EXTRACT(remark, '$.fillBlanks') AS fillBlanks
+FROM data_collection
+WHERE type = 1
+  AND remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks')
+  AND JSON_TYPE(JSON_EXTRACT(remark, '$.fillBlanks')) = 'OBJECT';
+
+-- 预期结果：0 行
+
+-- ============================================================
+-- 第六部分：迁移步骤四 — tableCellAnswers 从 Map 合并为 List，columnTolerances 从 Map 转为 List
+-- ============================================================
+-- 将 {"tableCellAnswers":{"A1":"3.5","B1":"4.2"},"cellTolerances":{"A1":5.0},"columnTolerances":{"A":3.0}} 转为
+--     {"tableCellAnswers":[{"cellPosition":"A1","value":"3.5","tolerance":5.0},{"cellPosition":"B1","value":"4.2"}],
+--      "columnTolerances":[{"columnName":"A","tolerance":3.0}]}
+
+-- 先处理 tableCellAnswers：Map → List（合并 cellTolerances）
+UPDATE data_collection dc
+SET dc.remark = JSON_SET(
+    dc.remark,
+    '$.tableCellAnswers',
+    (
+        SELECT JSON_ARRAYAGG(
+            JSON_OBJECT(
+                'cellPosition', jt.cell_pos,
+                'value', jt.cell_val,
+                'tolerance', JSON_UNQUOTE(JSON_EXTRACT(dc.remark, CONCAT('$.cellTolerances.', jt.cell_pos)))
+            )
+        )
+        FROM JSON_TABLE(
+            JSON_EXTRACT(dc.remark, '$.tableCellAnswers'),
+            '$[*]' COLUMNS (
+                cell_pos VARCHAR(255) PATH '$.key',
+                cell_val VARCHAR(255) PATH '$.value'
+            )
+        ) AS jt
+    )
+)
+WHERE dc.remark IS NOT NULL
+  AND dc.remark != ''
+  AND dc.type = 2
+  AND JSON_CONTAINS_PATH(dc.remark, 'one', '$.tableCellAnswers')
+  AND JSON_TYPE(JSON_EXTRACT(dc.remark, '$.tableCellAnswers')) = 'OBJECT';
+
+-- 移除已合并的 cellTolerances 字段
+UPDATE data_collection
+SET remark = JSON_REMOVE(remark, '$.cellTolerances')
+WHERE remark IS NOT NULL
+  AND remark != ''
+  AND type = 2
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.cellTolerances');
+
+-- 处理 columnTolerances：Map → List
+UPDATE data_collection dc
+SET dc.remark = JSON_SET(
+    dc.remark,
+    '$.columnTolerances',
+    (
+        SELECT JSON_ARRAYAGG(JSON_OBJECT('columnName', jt.col_name, 'tolerance', jt.col_tol))
+        FROM JSON_TABLE(
+            JSON_EXTRACT(dc.remark, '$.columnTolerances'),
+            '$[*]' COLUMNS (
+                col_name VARCHAR(255) PATH '$.key',
+                col_tol DECIMAL(10,2) PATH '$.value'
+            )
+        ) AS jt
+    )
+)
+WHERE dc.remark IS NOT NULL
+  AND dc.remark != ''
+  AND dc.type = 2
+  AND JSON_CONTAINS_PATH(dc.remark, 'one', '$.columnTolerances')
+  AND JSON_TYPE(JSON_EXTRACT(dc.remark, '$.columnTolerances')) = 'OBJECT';
+
+-- 验证步骤四
+SELECT id, type,
+       JSON_EXTRACT(remark, '$.tableCellAnswers') AS tableCellAnswers,
+       JSON_EXTRACT(remark, '$.columnTolerances') AS columnTolerances
+FROM data_collection
+WHERE type = 2
+  AND remark IS NOT NULL
+  AND remark != '';
+
+-- ============================================================
+-- 第七部分：迁移后最终验证
+-- ============================================================
+
+-- 1. 查看所有迁移后的 remark 数据
+SELECT id, type, remark
+FROM data_collection
+WHERE remark IS NOT NULL AND remark != ''
+ORDER BY id;
+
+-- 2. 确认所有填空类型记录都使用 fillBlanks (List 格式)
+SELECT id, type, remark
+FROM data_collection
+WHERE type = 1
+  AND remark IS NOT NULL
+  AND remark != ''
+  AND NOT JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks');
+
+-- 预期结果：0 行
+
+-- 3. 确认不再有 Map 格式的 fillBlanks
+SELECT id, type, remark
+FROM data_collection
+WHERE type = 1
+  AND remark IS NOT NULL
+  AND remark != ''
+  AND JSON_CONTAINS_PATH(remark, 'one', '$.fillBlanks')
+  AND JSON_TYPE(JSON_EXTRACT(remark, '$.fillBlanks')) = 'OBJECT';
+
+-- 预期结果：0 行
+
+-- ============================================================
+-- 第八部分：回滚方案（如需回退）
+-- ============================================================
+
+-- UPDATE data_collection dc
+-- INNER JOIN data_collection_remark_backup_20260415 bak ON dc.id = bak.id
+-- SET dc.remark = bak.remark;
+
+-- ============================================================
+-- 第九部分：清理（确认迁移成功后执行）
+-- ============================================================
+
+-- DROP TABLE IF EXISTS data_collection_remark_backup_20260415;


### PR DESCRIPTION
## Summary
- 将数据收集 remark 从旧 Map 结构重构为 DTO 列表结构，并补充移除 `dataType` 的迁移 SQL
- 将表格数据收集的单元格与列定位从 `cellPosition`/`columnName` 统一切换为 `rowIndex`/`columnIndex`
- 更新自动判分、请求对象与格式文档，前端需同步调整以下接口：`POST /api/teacher/procedure/data-collection/create`、`PUT /api/teacher/procedure/data-collection/update`、`POST /api/teacher/procedure/data-collection/insert`、`POST /api/student/procedure-submissions/data-collection/complete`、`PUT /api/student/procedure-submissions/data-collection/update`

## Test plan
- [ ] 验证教师端创建数据收集步骤时，填空与表格类型的 `remark` 和 `correct_answer` 落库格式符合新约定
- [ ] 验证学生端提交与修改表格数据时，`tableCellAnswers` 使用 `rowIndex-columnIndex` key 可正确保存与回显
- [ ] 验证自动判分按“单元格级 > 列级 > 步骤级”误差优先级生效
- [ ] 验证历史数据迁移脚本执行后，查询与判分链路正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)