### PR TITLE
新增课堂小测接口版本拆分

### DIFF
--- a/src/main/java/com/example/demo/config/JacksonConfig.java
+++ b/src/main/java/com/example/demo/config/JacksonConfig.java
@@ -1,0 +1,85 @@
+package com.example.demo.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Jackson 时间反序列化配置
+ * 无时区时间按 UTC+8 直接解析，带时区时间统一换算为 UTC+8 后存储。
+ */
+@Configuration
+public class JacksonConfig {
+
+    private static final ZoneId UTC_PLUS_8 = ZoneId.of("Asia/Shanghai");
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer localDateTimeCustomizer() {
+        return builder -> {
+            JavaTimeModule javaTimeModule = new JavaTimeModule();
+            javaTimeModule.addDeserializer(LocalDateTime.class, new JsonDeserializer<>() {
+                @Override
+                public LocalDateTime deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+                    String rawValue = parser.getText();
+                    if (rawValue == null || rawValue.trim().isEmpty()) {
+                        return null;
+                    }
+
+                    String normalizedValue = normalizeDateTime(rawValue.trim());
+
+                    try {
+                        if (containsTimezone(normalizedValue)) {
+                            return OffsetDateTime.parse(normalizedValue, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                                    .atZoneSameInstant(UTC_PLUS_8)
+                                    .toLocalDateTime();
+                        }
+
+                        return LocalDateTime.parse(normalizedValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                    } catch (DateTimeParseException ex) {
+                        throw new DateTimeParseException("无法解析时间", rawValue, ex.getErrorIndex(), ex);
+                    }
+                }
+            });
+            builder.modules(javaTimeModule);
+        };
+    }
+
+    private static boolean containsTimezone(String value) {
+        return value.endsWith("Z") || value.matches(".*[+-]\\d{2}:\\d{2}$");
+    }
+
+    private static String normalizeDateTime(String value) {
+        String normalized = value;
+        if (normalized.contains(" ") && !normalized.contains("T")) {
+            normalized = normalized.replaceFirst(" ", "T");
+        }
+
+        int separatorIndex = normalized.indexOf('T');
+        if (separatorIndex < 0) {
+            return normalized;
+        }
+
+        String[] dateParts = normalized.substring(0, separatorIndex).split("-");
+        if (dateParts.length != 3) {
+            return normalized;
+        }
+
+        String normalizedDate = String.format("%s-%02d-%02d",
+                dateParts[0],
+                Integer.parseInt(dateParts[1]),
+                Integer.parseInt(dateParts[2]));
+
+        return normalizedDate + normalized.substring(separatorIndex);
+    }
+}

--- a/src/main/java/com/example/demo/controller/teacher/TeacherClassroomQuizController.java
+++ b/src/main/java/com/example/demo/controller/teacher/TeacherClassroomQuizController.java
@@ -2,9 +2,11 @@ package com.example.demo.controller.teacher;
 
 import com.example.demo.annotation.RequireRole;
 import com.example.demo.enums.UserRole;
-import com.example.demo.pojo.response.ApiResponse;
 import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequest;
+import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequestV2;
+import com.example.demo.pojo.response.ApiResponse;
 import com.example.demo.pojo.response.ClassroomQuizHistoryResponse;
+import com.example.demo.pojo.response.ClassroomQuizHistoryResponseV2;
 import com.example.demo.pojo.response.ClassroomQuizStatisticsResponse;
 import com.example.demo.pojo.response.StudentClassroomQuizDetailResponse;
 import com.example.demo.service.TeacherClassroomQuizService;
@@ -27,11 +29,24 @@ public class TeacherClassroomQuizController {
     private final TeacherClassroomQuizService teacherClassroomQuizService;
 
     /**
-     * 创建课堂小测
+     * 创建课堂小测（旧版）
+     * 仅支持标签命中任一题目，不支持标签全匹配。
      */
+    @Deprecated
     @PostMapping
     @RequireRole(value = UserRole.TEACHER)
     public ApiResponse<Long> createClassroomQuiz(@RequestBody CreateClassroomQuizRequest request) {
+        Long quizId = teacherClassroomQuizService.createClassroomQuiz(request);
+        return ApiResponse.success(quizId, "创建成功");
+    }
+
+    /**
+     * 创建课堂小测（新版）
+     * 支持标签命中任一题目与必须命中全部标签两种模式。
+     */
+    @PostMapping("/v2")
+    @RequireRole(value = UserRole.TEACHER)
+    public ApiResponse<Long> createClassroomQuizV2(@RequestBody CreateClassroomQuizRequestV2 request) {
         Long quizId = teacherClassroomQuizService.createClassroomQuiz(request);
         return ApiResponse.success(quizId, "创建成功");
     }
@@ -81,13 +96,26 @@ public class TeacherClassroomQuizController {
     }
 
     /**
-     * 查询教师发布的历史小测列表
+     * 查询教师发布的历史小测列表（旧版）
+     * 旧版响应不包含标签全匹配方式。
      */
+    @Deprecated
     @GetMapping("/history")
     @RequireRole(value = UserRole.TEACHER)
-    public ApiResponse<List<ClassroomQuizHistoryResponse>> getHistoryQuizzes(
+    public ApiResponse<List<ClassroomQuizHistoryResponse>> getHistoryQuizzesLegacy(
             @RequestParam(value = "classExperimentId", required = false) Long classExperimentId) {
-        List<ClassroomQuizHistoryResponse> quizzes = teacherClassroomQuizService.getHistoryQuizzes(classExperimentId);
+        List<ClassroomQuizHistoryResponse> quizzes = teacherClassroomQuizService.getHistoryQuizzesLegacy(classExperimentId);
+        return ApiResponse.success(quizzes, "查询成功");
+    }
+
+    /**
+     * 查询教师发布的历史小测列表（新版）
+     */
+    @GetMapping("/history/v2")
+    @RequireRole(value = UserRole.TEACHER)
+    public ApiResponse<List<ClassroomQuizHistoryResponseV2>> getHistoryQuizzesV2(
+            @RequestParam(value = "classExperimentId", required = false) Long classExperimentId) {
+        List<ClassroomQuizHistoryResponseV2> quizzes = teacherClassroomQuizService.getHistoryQuizzes(classExperimentId);
         return ApiResponse.success(quizzes, "查询成功");
     }
 }

--- a/src/main/java/com/example/demo/controller/teacher/TeacherProcedureController.java
+++ b/src/main/java/com/example/demo/controller/teacher/TeacherProcedureController.java
@@ -81,6 +81,21 @@ public class TeacherProcedureController {
     }
 
     /**
+     * 按指定课次重新机器自动批改
+     *
+     * @param classExperimentId 班级实验ID
+     * @return 重批结果统计
+     */
+    @PostMapping("/class-experiments/{classExperimentId}/re-auto-grade")
+    @RequireRole(value = UserRole.TEACHER)
+    public ApiResponse<StudentProcedureSubmissionService.ReAutoGradeSummary> reAutoGradeByClassExperimentId(
+            @PathVariable("classExperimentId") Long classExperimentId) {
+        StudentProcedureSubmissionService.ReAutoGradeSummary summary =
+                studentProcedureSubmissionService.reAutoGradeByClassExperimentId(classExperimentId);
+        return ApiResponse.success(summary, "重新机器批改完成");
+    }
+
+    /**
      * 批改实验步骤请求
      */
     @Data

--- a/src/main/java/com/example/demo/pojo/entity/ProcedureTopic.java
+++ b/src/main/java/com/example/demo/pojo/entity/ProcedureTopic.java
@@ -45,6 +45,10 @@ public class ProcedureTopic {
     @Column(comment = "题目类型限制（仅在随机抽取时有效，格式 1,2,3）" , type = "varchar(255)")
     private String topicTypes;
 
+    /** 标签匹配方式：0-命中任一标签，1-必须命中全部标签 */
+    @Column(comment = "标签匹配方式：0-命中任一标签，1-必须命中全部标签", type = "bit", defaultValue = "1", notNull = true)
+    private Boolean tagMatchAll;
+
     /** 创建时间 */
     @Column(comment = "创建时间", type = "datetime", defaultValue = "CURRENT_TIMESTAMP")
     private LocalDateTime createdTime;

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequest.java
@@ -50,6 +50,13 @@ public class CreateClassroomQuizRequest {
     private List<Long> topicTags;
 
     /**
+     * 标签匹配方式
+     * false: 命中任一标签
+     * true: 必须命中全部标签
+     */
+    private Boolean tagMatchAll;
+
+    /**
      * 题目类型列表（仅在随机抽取时有效）
      * 1-单选，2-多选，3-判断，4-填空，6-其他
      */

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequestLegacy.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequestLegacy.java
@@ -1,0 +1,57 @@
+package com.example.demo.pojo.request.teacher;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 创建课堂小测请求（旧版）
+ */
+@Data
+public class CreateClassroomQuizRequestLegacy {
+
+    /**
+     * 班级实验ID
+     */
+    private Long classExperimentId;
+
+    /**
+     * 小测标题
+     */
+    private String quizTitle;
+
+    /**
+     * 小测描述
+     */
+    private String quizDescription;
+
+    /**
+     * 答题时间限制（分钟）
+     */
+    private Integer quizTimeLimit;
+
+    /**
+     * 是否随机抽取
+     */
+    private Boolean isRandom;
+
+    /**
+     * 题目数量（仅在随机抽取时有效）
+     */
+    private Integer topicNumber;
+
+    /**
+     * 标签ID列表（仅在随机抽取时有效）
+     */
+    private List<Long> topicTags;
+
+    /**
+     * 题目类型列表（仅在随机抽取时有效）
+     */
+    private List<Integer> topicTypes;
+
+    /**
+     * 老师选定的题目ID列表（仅在非随机模式时有效）
+     */
+    private List<Long> teacherSelectedTopicIds;
+}

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequestV2.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateClassroomQuizRequestV2.java
@@ -1,0 +1,99 @@
+package com.example.demo.pojo.request.teacher;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 创建课堂小测请求（新版）
+ */
+@Data
+public class CreateClassroomQuizRequestV2 {
+
+    /**
+     * 班级实验ID
+     */
+    private Long classExperimentId;
+
+    /**
+     * 小测标题
+     */
+    private String quizTitle;
+
+    /**
+     * 小测描述
+     */
+    private String quizDescription;
+
+    /**
+     * 答题时间限制（分钟）
+     */
+    private Integer quizTimeLimit;
+
+    /**
+     * 是否随机抽取
+     */
+    private Boolean isRandom;
+
+    /**
+     * 题目数量（仅在随机抽取时有效）
+     */
+    private Integer topicNumber;
+
+    /**
+     * 标签ID列表（仅在随机抽取时有效）
+     */
+    private List<Long> topicTags;
+
+    /**
+     * 标签匹配方式
+     * false: 命中任一标签
+     * true: 必须命中全部标签
+     */
+    private Boolean tagMatchAll;
+
+    /**
+     * 题目类型列表（仅在随机抽取时有效）
+     */
+    private List<Integer> topicTypes;
+
+    /**
+     * 老师选定的题目ID列表（仅在非随机模式时有效）
+     */
+    private List<Long> teacherSelectedTopicIds;
+
+    public static CreateClassroomQuizRequestV2 fromLegacy(CreateClassroomQuizRequest request) {
+        if (request == null) {
+            return null;
+        }
+        CreateClassroomQuizRequestV2 target = new CreateClassroomQuizRequestV2();
+        target.setClassExperimentId(request.getClassExperimentId());
+        target.setQuizTitle(request.getQuizTitle());
+        target.setQuizDescription(request.getQuizDescription());
+        target.setQuizTimeLimit(request.getQuizTimeLimit());
+        target.setIsRandom(request.getIsRandom());
+        target.setTopicNumber(request.getTopicNumber());
+        target.setTopicTags(request.getTopicTags());
+        target.setTagMatchAll(Boolean.FALSE);
+        target.setTopicTypes(request.getTopicTypes());
+        target.setTeacherSelectedTopicIds(request.getTeacherSelectedTopicIds());
+        return target;
+    }
+
+    public static CreateClassroomQuizRequest toLegacy(CreateClassroomQuizRequestV2 request) {
+        if (request == null) {
+            return null;
+        }
+        CreateClassroomQuizRequest target = new CreateClassroomQuizRequest();
+        target.setClassExperimentId(request.getClassExperimentId());
+        target.setQuizTitle(request.getQuizTitle());
+        target.setQuizDescription(request.getQuizDescription());
+        target.setQuizTimeLimit(request.getQuizTimeLimit());
+        target.setIsRandom(request.getIsRandom());
+        target.setTopicNumber(request.getTopicNumber());
+        target.setTopicTags(request.getTopicTags());
+        target.setTopicTypes(request.getTopicTypes());
+        target.setTeacherSelectedTopicIds(request.getTeacherSelectedTopicIds());
+        return target;
+    }
+}

--- a/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponse.java
@@ -62,6 +62,9 @@ public class ClassroomQuizHistoryResponse {
         /** 题目类型限制（仅在随机抽取时有效） */
         private String topicTypes;
 
+        /** 标签匹配方式：false-命中任一标签，true-必须命中全部标签 */
+        private Boolean tagMatchAll;
+
         /** 选定的题目数量（非随机模式下） */
         private Integer selectedTopicCount;
 
@@ -104,6 +107,7 @@ public class ClassroomQuizHistoryResponse {
             info.setNumber(entity.getNumber());
             info.setTags(entity.getTags());
             info.setTopicTypes(entity.getTopicTypes());
+            info.setTagMatchAll(entity.getTagMatchAll());
             info.setSelectedTopicCount(selectedTopicCount);
             return info;
         }

--- a/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponseLegacy.java
+++ b/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponseLegacy.java
@@ -1,0 +1,80 @@
+package com.example.demo.pojo.response;
+
+import com.example.demo.pojo.entity.ProcedureTopic;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 教师历史小测响应（旧版）
+ */
+@Data
+public class ClassroomQuizHistoryResponseLegacy {
+
+    /** 小测ID */
+    private Long id;
+
+    /** 班级实验ID */
+    private Long classExperimentId;
+
+    /** 小测标题 */
+    private String quizTitle;
+
+    /** 小测描述 */
+    private String quizDescription;
+
+    /** 答题时间限制（分钟） */
+    private Integer quizTimeLimit;
+
+    /** 状态:0-未开始,1-进行中,2-已结束 */
+    private Integer status;
+
+    /** 开始时间 */
+    private LocalDateTime startTime;
+
+    /** 结束时间 */
+    private LocalDateTime endTime;
+
+    /** 创建者(教师用户名) */
+    private String createdBy;
+
+    /** 创建时间 */
+    private LocalDateTime createdTime;
+
+    /** 题库配置信息 */
+    private ProcedureTopicInfo procedureTopic;
+
+    @Data
+    public static class ProcedureTopicInfo {
+        private Boolean isRandom;
+        private Integer number;
+        private String tags;
+        private String topicTypes;
+        private Integer selectedTopicCount;
+        private List<TopicInfo> topics;
+
+        @Data
+        public static class TopicInfo {
+            private Long topicId;
+            private Integer number;
+            private Integer type;
+            private String content;
+            private String choices;
+            private String correctAnswer;
+        }
+
+        public static ProcedureTopicInfo fromEntity(ProcedureTopic entity, Integer selectedTopicCount) {
+            if (entity == null) {
+                return null;
+            }
+            ProcedureTopicInfo info = new ProcedureTopicInfo();
+            info.setIsRandom(entity.getIsRandom());
+            info.setNumber(entity.getNumber());
+            info.setTags(entity.getTags());
+            info.setTopicTypes(entity.getTopicTypes());
+            info.setSelectedTopicCount(selectedTopicCount);
+            return info;
+        }
+    }
+}

--- a/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponseV2.java
+++ b/src/main/java/com/example/demo/pojo/response/ClassroomQuizHistoryResponseV2.java
@@ -1,0 +1,82 @@
+package com.example.demo.pojo.response;
+
+import com.example.demo.pojo.entity.ProcedureTopic;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 教师历史小测响应（新版）
+ */
+@Data
+public class ClassroomQuizHistoryResponseV2 {
+
+    /** 小测ID */
+    private Long id;
+
+    /** 班级实验ID */
+    private Long classExperimentId;
+
+    /** 小测标题 */
+    private String quizTitle;
+
+    /** 小测描述 */
+    private String quizDescription;
+
+    /** 答题时间限制（分钟） */
+    private Integer quizTimeLimit;
+
+    /** 状态:0-未开始,1-进行中,2-已结束 */
+    private Integer status;
+
+    /** 开始时间 */
+    private LocalDateTime startTime;
+
+    /** 结束时间 */
+    private LocalDateTime endTime;
+
+    /** 创建者(教师用户名) */
+    private String createdBy;
+
+    /** 创建时间 */
+    private LocalDateTime createdTime;
+
+    /** 题库配置信息 */
+    private ProcedureTopicInfo procedureTopic;
+
+    @Data
+    public static class ProcedureTopicInfo {
+        private Boolean isRandom;
+        private Integer number;
+        private String tags;
+        private String topicTypes;
+        private Boolean tagMatchAll;
+        private Integer selectedTopicCount;
+        private List<TopicInfo> topics;
+
+        @Data
+        public static class TopicInfo {
+            private Long topicId;
+            private Integer number;
+            private Integer type;
+            private String content;
+            private String choices;
+            private String correctAnswer;
+        }
+
+        public static ProcedureTopicInfo fromEntity(ProcedureTopic entity, Integer selectedTopicCount) {
+            if (entity == null) {
+                return null;
+            }
+            ProcedureTopicInfo info = new ProcedureTopicInfo();
+            info.setIsRandom(entity.getIsRandom());
+            info.setNumber(entity.getNumber());
+            info.setTags(entity.getTags());
+            info.setTopicTypes(entity.getTopicTypes());
+            info.setTagMatchAll(entity.getTagMatchAll());
+            info.setSelectedTopicCount(selectedTopicCount);
+            return info;
+        }
+    }
+}

--- a/src/main/java/com/example/demo/service/StudentExperimentalProcedureService.java
+++ b/src/main/java/com/example/demo/service/StudentExperimentalProcedureService.java
@@ -39,6 +39,7 @@ public class StudentExperimentalProcedureService extends ServiceImpl<StudentExpe
     private final ClassExperimentMapper classExperimentMapper;
     private final ClassExperimentClassRelationMapper classExperimentClassRelationMapper;
     private final StudentProcedureExtensionService studentProcedureExtensionService;
+    private final ClassExperimentClassRelationService classExperimentClassRelationService;
 
     /**
      * 查询学生在指定班级实验中的所有步骤答案
@@ -235,6 +236,8 @@ public class StudentExperimentalProcedureService extends ServiceImpl<StudentExpe
         studentProcedure.setExperimentId(procedure.getExperimentId());
         studentProcedure.setStudentUsername(studentUsername);
         studentProcedure.setClassCode(classCode);
+        StudentProcedureCompletionService.getClassExperimentId(classCode, procedure, studentProcedure, classExperimentClassRelationMapper, classExperimentMapper);
+
         studentProcedure.setExperimentalProcedureId(experimentalProcedureId);
         studentProcedure.setNumber(procedure.getNumber());
         studentProcedure.setAnswer(AnswerMapJSONUntil.buildVideo());

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -3,20 +3,8 @@ package com.example.demo.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.example.demo.exception.BusinessException;
-import com.example.demo.mapper.DataCollectionMapper;
-import com.example.demo.mapper.ProcedureTopicMapper;
-import com.example.demo.mapper.ProcedureTopicMapMapper;
-import com.example.demo.mapper.StudentProcedureAttachmentMapper;
-import com.example.demo.mapper.TimedQuizProcedureMapper;
-import com.example.demo.mapper.TopicMapper;
-import com.example.demo.pojo.entity.DataCollection;
-import com.example.demo.pojo.entity.ExperimentalProcedure;
-import com.example.demo.pojo.entity.ProcedureTopic;
-import com.example.demo.pojo.entity.ProcedureTopicMap;
-import com.example.demo.pojo.entity.StudentExperimentalProcedure;
-import com.example.demo.pojo.entity.StudentProcedureAttachment;
-import com.example.demo.pojo.entity.TimedQuizProcedure;
-import com.example.demo.pojo.entity.Topic;
+import com.example.demo.mapper.*;
+import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.request.student.CompleteTimedQuizProcedureRequest;
 import com.example.demo.util.AnswerMapJSONUntil;
 import com.example.demo.util.DataCollectionDataUtil;
@@ -61,6 +49,8 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
     private final TopicMapper topicMapper;
     private final TimedQuizKeyGenerator timedQuizKeyGenerator;
+    private final ClassExperimentMapper classExperimentMapper;
+    private final ClassExperimentClassRelationMapper classExperimentClassRelationMapper;
 
     @Value("${file.upload.path}")
     private String uploadBasePath;
@@ -136,6 +126,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
         studentProcedure.setNumber(procedure.getNumber());
         studentProcedure.setAnswer(AnswerMapJSONUntil.toTopicJson(normalizedAnswers));
         studentProcedure.setCreatedTime(LocalDateTime.now());
+        getClassExperimentId(classCode, procedure, studentProcedure, classExperimentClassRelationMapper, classExperimentMapper);
 
         boolean saved = studentExperimentalProcedureService.save(studentProcedure);
         if (!saved) {
@@ -146,6 +137,12 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
 
         log.info("学生 {} 在班级 {} 完成题库练习，步骤：{}，题目数：{}",
                 studentUsername, classCode, procedureId, normalizedAnswers.size());
+    }
+
+    static void getClassExperimentId(String classCode, ExperimentalProcedure procedure, StudentExperimentalProcedure studentProcedure, ClassExperimentClassRelationMapper classExperimentClassRelationMapper, ClassExperimentMapper classExperimentMapper) {
+        List<Long> list = classExperimentClassRelationMapper.selectList(new LambdaQueryWrapper<ClassExperimentClassRelation>().eq(ClassExperimentClassRelation::getClassCode, classCode)).stream().map(ClassExperimentClassRelation::getId).toList();
+        ClassExperiment classExperiment = classExperimentMapper.selectOne(new LambdaQueryWrapper<ClassExperiment>().in(ClassExperiment::getId, list).eq(ClassExperiment::getExperimentId, procedure.getExperimentId()), false);
+        studentProcedure.setClassExperimentId(classExperiment.getId());
     }
 
     /**
@@ -253,6 +250,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
         studentProcedure.setClassCode(classCode);
         studentProcedure.setExperimentalProcedureId(procedureId);
         studentProcedure.setNumber(procedure.getNumber());
+        getClassExperimentId(classCode,procedure,studentProcedure,classExperimentClassRelationMapper,classExperimentMapper);
 
         // 根据数据类型生成不同的答案 JSON
         if (dataType == 3) {
@@ -1086,6 +1084,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
         studentProcedure.setAnswer(AnswerMapJSONUntil.toTimedQuizJson(normalizedAnswers));
         studentProcedure.setIsLocked(true);  // 锁定答案，不允许修改
         studentProcedure.setCreatedTime(LocalDateTime.now());
+        getClassExperimentId(classCode,procedure,studentProcedure,classExperimentClassRelationMapper,classExperimentMapper);
 
         boolean saved = studentExperimentalProcedureService.save(studentProcedure);
         if (!saved) {

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -140,8 +140,22 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
     }
 
     static void getClassExperimentId(String classCode, ExperimentalProcedure procedure, StudentExperimentalProcedure studentProcedure, ClassExperimentClassRelationMapper classExperimentClassRelationMapper, ClassExperimentMapper classExperimentMapper) {
-        List<Long> list = classExperimentClassRelationMapper.selectList(new LambdaQueryWrapper<ClassExperimentClassRelation>().eq(ClassExperimentClassRelation::getClassCode, classCode)).stream().map(ClassExperimentClassRelation::getId).toList();
-        ClassExperiment classExperiment = classExperimentMapper.selectOne(new LambdaQueryWrapper<ClassExperiment>().in(ClassExperiment::getId, list).eq(ClassExperiment::getExperimentId, procedure.getExperimentId()), false);
+        List<Long> list = classExperimentClassRelationMapper.selectList(
+                new LambdaQueryWrapper<ClassExperimentClassRelation>()
+                        .eq(ClassExperimentClassRelation::getClassCode, classCode)
+        ).stream().map(ClassExperimentClassRelation::getClassExperimentId).toList();
+        if (list.isEmpty()) {
+            throw new BusinessException(404, "班级未关联任何课次");
+        }
+        ClassExperiment classExperiment = classExperimentMapper.selectOne(
+                new LambdaQueryWrapper<ClassExperiment>()
+                        .in(ClassExperiment::getId, list)
+                        .eq(ClassExperiment::getExperimentId, procedure.getExperimentId()),
+                false
+        );
+        if (classExperiment == null) {
+            throw new BusinessException(404, "未找到匹配的课次");
+        }
         studentProcedure.setClassExperimentId(classExperiment.getId());
     }
 

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -22,6 +22,8 @@ import com.example.demo.util.AnswerMapJSONUntil;
 import com.example.demo.util.DataCollectionDataUtil;
 import com.example.demo.util.TimedQuizKeyGenerator;
 import com.example.demo.util.TopicAnswerContractUtil;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -64,6 +67,10 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
 
     /** 步骤附件存储子目录 */
     private static final String ATTACHMENT_SUB_PATH = "attachments";
+
+    private static final Integer GRADE_STATUS_NOT_GRADED = 0;
+    private static final Integer GRADE_STATUS_TEACHER_GRADED = 1;
+    private static final Integer GRADE_STATUS_AUTO_GRADED = 2;
 
     /**
      * 完成题库练习（类型3）
@@ -258,8 +265,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             throw new BusinessException(500, "提交数据收集失败");
         }
 
-        // 6. 自动判分（只有 dataType 为 1 或 2 时才进行自动判分）
-        if (dataType != 3) {
+        if (shouldTriggerAutoGrade(dataType)) {
             autoGradeDataCollectionProcedure(procedureId, studentProcedure.getId(),
                                              fillBlankAnswers, tableCellAnswers);
         }
@@ -353,7 +359,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
      * @param fillBlankAnswers   填空类型答案
      * @param tableCellAnswers   表格类型答案
      */
-    private void autoGradeDataCollectionProcedure(Long procedureId, Long studentAnswerId,
+    private AutoGradeExecutionResult autoGradeDataCollectionProcedure(Long procedureId, Long studentAnswerId,
                                                   java.util.Map<String, String> fillBlankAnswers,
                                                   java.util.Map<String, String> tableCellAnswers) {
         try {
@@ -362,10 +368,16 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             queryWrapper.eq(DataCollection::getExperimentalProcedureId, procedureId);
             DataCollection dataCollection = dataCollectionMapper.selectOne(queryWrapper);
 
-            if (dataCollection == null || dataCollection.getCorrectAnswer() == null
-                    || dataCollection.getCorrectAnswer().trim().isEmpty()) {
-                // 没有配置正确答案，不进行自动判分
-                return;
+            if (dataCollection == null) {
+                return AutoGradeExecutionResult.skipped("数据收集配置不存在");
+            }
+
+            if (!shouldTriggerAutoGrade(dataCollection.getType())) {
+                return AutoGradeExecutionResult.skipped("当前步骤不支持机器批改");
+            }
+
+            if (dataCollection.getCorrectAnswer() == null || dataCollection.getCorrectAnswer().trim().isEmpty()) {
+                return AutoGradeExecutionResult.skipped("未配置正确答案");
             }
 
             // 2. 解析正确答案和误差配置
@@ -376,7 +388,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             );
 
             if (correctAnswers == null || correctAnswers.isEmpty()) {
-                return;
+                return AutoGradeExecutionResult.skipped("正确答案为空");
             }
 
             // 解析字段级/单元格级/列级误差配置
@@ -437,19 +449,25 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
 
             // 5. 更新学生答案记录
             StudentExperimentalProcedure studentProcedure = studentExperimentalProcedureService.getById(studentAnswerId);
-            if (studentProcedure != null) {
-                studentProcedure.setScore(score);
-                studentProcedure.setIsGraded(2); // 2-系统自动评分
-                studentProcedure.setTeacherComment("系统自动评分");
-                studentExperimentalProcedureService.updateById(studentProcedure);
-
-                log.info("自动判分完成，步骤ID：{}，学生答案ID：{}，得分：{}/{}",
-                        procedureId, studentAnswerId, score, totalQuestions);
+            if (studentProcedure == null) {
+                return AutoGradeExecutionResult.failed("学生答案记录不存在");
             }
+            if (!canAutoGradeRecord(studentProcedure)) {
+                return AutoGradeExecutionResult.skipped("人工批改记录跳过");
+            }
+
+            studentProcedure.setScore(score);
+            studentProcedure.setIsGraded(GRADE_STATUS_AUTO_GRADED);
+            studentProcedure.setTeacherComment("系统自动评分");
+            studentExperimentalProcedureService.updateById(studentProcedure);
+
+            log.info("自动判分完成，步骤ID：{}，学生答案ID：{}，得分：{}/{}",
+                    procedureId, studentAnswerId, score, totalQuestions);
+            return AutoGradeExecutionResult.success("自动判分成功");
 
         } catch (Exception e) {
             log.error("自动判分失败", e);
-            // 判分失败不影响提交，只记录日志
+            return AutoGradeExecutionResult.failed("自动判分失败: " + e.getMessage());
         }
     }
 
@@ -730,9 +748,10 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
         } else {
             studentProcedure.setAnswer(AnswerMapJSONUntil.toDataCollectionJson(fillBlankAnswers, tableCellAnswers));
         }
-        studentProcedure.setScore(null);
-        studentProcedure.setIsGraded(0);
-        studentProcedure.setTeacherComment(null);
+
+        if (canAutoGradeRecord(studentProcedure)) {
+            resetMachineGrade(studentProcedure);
+        }
 
         boolean updated = studentExperimentalProcedureService.updateById(studentProcedure);
         if (!updated) {
@@ -754,13 +773,126 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             }
         }
 
-        // 8. 重新自动判分（只有 dataType 为 1 或 2 时才进行自动判分）
-        if (dataType != 3) {
+        // 8. 重新自动判分
+        if (shouldTriggerAutoGrade(dataType) && canAutoGradeRecord(studentProcedure)) {
             autoGradeDataCollectionProcedure(procedureId, studentProcedure.getId(),
                                              fillBlankAnswers, tableCellAnswers);
         }
 
         log.info("学生 {} 在班级 {} 修改数据收集，步骤：{}", studentUsername, classCode, procedureId);
+    }
+
+    private boolean shouldTriggerAutoGrade(Long dataType) {
+        return dataType != null && (dataType == 1L || dataType == 2L);
+    }
+
+    private boolean canAutoGradeRecord(StudentExperimentalProcedure studentProcedure) {
+        return studentProcedure == null
+                || studentProcedure.getIsGraded() == null
+                || GRADE_STATUS_NOT_GRADED.equals(studentProcedure.getIsGraded())
+                || GRADE_STATUS_AUTO_GRADED.equals(studentProcedure.getIsGraded());
+    }
+
+    private void resetMachineGrade(StudentExperimentalProcedure studentProcedure) {
+        studentProcedure.setScore(null);
+        studentProcedure.setIsGraded(GRADE_STATUS_NOT_GRADED);
+        studentProcedure.setTeacherComment(null);
+    }
+
+    public AutoGradeExecutionResult autoGradeExistingDataCollectionSubmission(Long studentProcedureId) {
+        StudentExperimentalProcedure studentProcedure = studentExperimentalProcedureService.getById(studentProcedureId);
+        if (studentProcedure == null) {
+            return AutoGradeExecutionResult.skipped("提交记录不存在");
+        }
+        if (!canAutoGradeRecord(studentProcedure)) {
+            return AutoGradeExecutionResult.skipped("人工批改记录跳过");
+        }
+
+        ExperimentalProcedure procedure = experimentalProcedureService.getById(studentProcedure.getExperimentalProcedureId());
+        if (procedure == null || procedure.getIsDeleted() || !Integer.valueOf(2).equals(procedure.getType())) {
+            return AutoGradeExecutionResult.skipped("非数据收集步骤");
+        }
+
+        LambdaQueryWrapper<DataCollection> queryWrapper = new LambdaQueryWrapper<>();
+        queryWrapper.eq(DataCollection::getExperimentalProcedureId, procedure.getId());
+        DataCollection dataCollection = dataCollectionMapper.selectOne(queryWrapper);
+        if (dataCollection == null || !shouldTriggerAutoGrade(dataCollection.getType())) {
+            return AutoGradeExecutionResult.skipped("当前步骤不支持机器批改");
+        }
+
+        DataCollectionAnswerMaps answerMaps = parseStoredDataCollectionAnswer(studentProcedure.getAnswer());
+        if (answerMaps.isEmpty()) {
+            return AutoGradeExecutionResult.failed("学生答案为空或解析失败");
+        }
+
+        resetMachineGrade(studentProcedure);
+        boolean updated = studentExperimentalProcedureService.updateById(studentProcedure);
+        if (!updated) {
+            return AutoGradeExecutionResult.failed("重置机器评分状态失败");
+        }
+
+        return autoGradeDataCollectionProcedure(
+                procedure.getId(),
+                studentProcedureId,
+                answerMaps.getFillBlankAnswers(),
+                answerMaps.getTableCellAnswers()
+        );
+    }
+
+    private DataCollectionAnswerMaps parseStoredDataCollectionAnswer(String answerJson) {
+        Map<String, Object> dataMap = AnswerMapJSONUntil.parseDataAsObject(answerJson);
+        if (dataMap == null || dataMap.isEmpty()) {
+            return new DataCollectionAnswerMaps(null, null);
+        }
+        Map<String, String> fillBlankAnswers = convertToStringMap(dataMap.get("fillBlankAnswers"));
+        Map<String, String> tableCellAnswers = convertToStringMap(dataMap.get("tableCellAnswers"));
+        return new DataCollectionAnswerMaps(fillBlankAnswers, tableCellAnswers);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> convertToStringMap(Object value) {
+        if (!(value instanceof Map<?, ?> rawMap) || rawMap.isEmpty()) {
+            return null;
+        }
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                result.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class AutoGradeExecutionResult {
+        private boolean success;
+        private boolean skipped;
+        private String message;
+
+        public static AutoGradeExecutionResult success(String message) {
+            return new AutoGradeExecutionResult(true, false, message);
+        }
+
+        public static AutoGradeExecutionResult skipped(String message) {
+            return new AutoGradeExecutionResult(false, true, message);
+        }
+
+        public static AutoGradeExecutionResult failed(String message) {
+            return new AutoGradeExecutionResult(false, false, message);
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class DataCollectionAnswerMaps {
+        private Map<String, String> fillBlankAnswers;
+        private Map<String, String> tableCellAnswers;
+
+        private boolean isEmpty() {
+            return (fillBlankAnswers == null || fillBlankAnswers.isEmpty())
+                    && (tableCellAnswers == null || tableCellAnswers.isEmpty());
+        }
     }
 
     /**

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -142,6 +142,8 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             throw new BusinessException(500, "提交题库答案失败");
         }
 
+        autoGradeTopicProcedure(studentProcedure.getId(), normalizedAnswers);
+
         log.info("学生 {} 在班级 {} 完成题库练习，步骤：{}，题目数：{}",
                 studentUsername, classCode, procedureId, normalizedAnswers.size());
     }
@@ -610,6 +612,8 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             throw new BusinessException(500, "修改题库答案失败");
         }
 
+        autoGradeTopicProcedure(studentProcedure.getId(), normalizedAnswers);
+
         log.info("学生 {} 在班级 {} 修改题库练习，步骤：{}，题目数：{}",
                 studentUsername, classCode, procedureId, normalizedAnswers.size());
     }
@@ -784,6 +788,57 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
 
     private boolean shouldTriggerAutoGrade(Long dataType) {
         return dataType != null && (dataType == 1L || dataType == 2L);
+    }
+
+    private void autoGradeTopicProcedure(Long studentProcedureId, Map<Long, String> answers) {
+        StudentExperimentalProcedure studentProcedure = studentExperimentalProcedureService.getById(studentProcedureId);
+        if (studentProcedure == null) {
+            throw new BusinessException(500, "题库答案记录不存在");
+        }
+
+        try {
+            if (answers == null || answers.isEmpty()) {
+                resetMachineGrade(studentProcedure);
+                studentExperimentalProcedureService.updateById(studentProcedure);
+                return;
+            }
+
+            List<Topic> topics = loadTopicsByIds(answers.keySet());
+            if (topics.size() != answers.size()) {
+                resetMachineGrade(studentProcedure);
+                studentExperimentalProcedureService.updateById(studentProcedure);
+                return;
+            }
+
+            Map<Long, Topic> topicMap = new HashMap<>();
+            for (Topic topic : topics) {
+                topicMap.put(topic.getId(), topic);
+            }
+
+            int totalCount = answers.size();
+            int correctCount = 0;
+            for (Map.Entry<Long, String> entry : answers.entrySet()) {
+                Topic topic = topicMap.get(entry.getKey());
+                if (topic == null || topic.getCorrectAnswer() == null || topic.getCorrectAnswer().trim().isEmpty()) {
+                    resetMachineGrade(studentProcedure);
+                    studentExperimentalProcedureService.updateById(studentProcedure);
+                    return;
+                }
+                if (TopicAnswerContractUtil.answersEqual(topic.getType(), entry.getValue(), topic.getCorrectAnswer())) {
+                    correctCount++;
+                }
+            }
+
+            studentProcedure.setScore(new java.math.BigDecimal(correctCount * 100.0 / totalCount)
+                    .setScale(2, RoundingMode.HALF_UP));
+            studentProcedure.setIsGraded(GRADE_STATUS_AUTO_GRADED);
+            studentProcedure.setTeacherComment("系统自动评分");
+            studentExperimentalProcedureService.updateById(studentProcedure);
+        } catch (Exception e) {
+            log.error("题库练习自动评分失败，studentProcedureId={}", studentProcedureId, e);
+            resetMachineGrade(studentProcedure);
+            studentExperimentalProcedureService.updateById(studentProcedure);
+        }
     }
 
     private boolean canAutoGradeRecord(StudentExperimentalProcedure studentProcedure) {

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 学生步骤查询服务
@@ -46,6 +47,8 @@ public class StudentProcedureQueryService {
     private final ClassExperimentClassRelationService classExperimentClassRelationService;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
     private final TimedQuizKeyGenerator timedQuizKeyGenerator;
+    private final ClassExperimentClassRelationMapper classExperimentClassRelationMapper;
+    private final StudentClassRelationMapper studentClassRelationMapper;
 
     /**
      * 查询已提交的步骤详情（带答案）
@@ -71,8 +74,8 @@ public class StudentProcedureQueryService {
 
         // 查询学生提交记录
         LambdaQueryWrapper<StudentExperimentalProcedure> wrapper = new LambdaQueryWrapper<>();
-        wrapper.eq(StudentExperimentalProcedure::getExperimentalProcedureId, procedureId);
-        wrapper.eq(StudentExperimentalProcedure::getStudentUsername, username);
+            wrapper.eq(StudentExperimentalProcedure::getExperimentalProcedureId, procedureId);
+            wrapper.eq(StudentExperimentalProcedure::getStudentUsername, username);
         StudentExperimentalProcedure studentProcedure = studentExperimentalProcedureMapper.selectOne(wrapper);
 
         if (studentProcedure == null) {
@@ -83,10 +86,19 @@ public class StudentProcedureQueryService {
         boolean isAfterEndTime = false;
         try {
             // 查询班级实验
-            LambdaQueryWrapper<com.example.demo.pojo.entity.ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
-            classExperimentWrapper.eq(com.example.demo.pojo.entity.ClassExperiment::getCourseId, courseId);
-            classExperimentWrapper.eq(com.example.demo.pojo.entity.ClassExperiment::getExperimentId, experimentId);
-            com.example.demo.pojo.entity.ClassExperiment classExperiment = classExperimentMapper.selectOne(classExperimentWrapper);
+            LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
+
+            if (studentProcedure.getClassExperimentId() == null) {
+                StudentClassRelation studentClassRelation = studentClassRelationMapper.selectOne(new LambdaQueryWrapper<StudentClassRelation>().eq(StudentClassRelation::getStudentUsername, username), false);
+                Stream<Long> longStream = classExperimentClassRelationMapper.selectList(new LambdaQueryWrapper<ClassExperimentClassRelation>().eq(ClassExperimentClassRelation::getClassCode, studentClassRelation.getClassCode())).stream().map(ClassExperimentClassRelation::getClassExperimentId);
+                classExperimentWrapper.in(ClassExperiment::getId, longStream);
+                classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
+                classExperimentWrapper.eq(ClassExperiment::getExperimentId, experimentId);
+            }else {
+                classExperimentWrapper.eq(ClassExperiment::getId, studentProcedure.getClassExperimentId());
+            }
+
+            ClassExperiment classExperiment = classExperimentMapper.selectOne(classExperimentWrapper,false);
 
             if (classExperiment != null && procedure.getOffsetMinutes() != null) {
                 // 使用工具类计算步骤时间

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -89,11 +89,24 @@ public class StudentProcedureQueryService {
             LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
 
             if (studentProcedure.getClassExperimentId() == null) {
-                StudentClassRelation studentClassRelation = studentClassRelationMapper.selectOne(new LambdaQueryWrapper<StudentClassRelation>().eq(StudentClassRelation::getStudentUsername, username), false);
-                Stream<Long> longStream = classExperimentClassRelationMapper.selectList(new LambdaQueryWrapper<ClassExperimentClassRelation>().eq(ClassExperimentClassRelation::getClassCode, studentClassRelation.getClassCode())).stream().map(ClassExperimentClassRelation::getClassExperimentId);
+                StudentClassRelation studentClassRelation = studentClassRelationMapper.selectOne(
+                        new LambdaQueryWrapper<StudentClassRelation>()
+                                .eq(StudentClassRelation::getStudentUsername, username),
+                        false
+                );
+                if (studentClassRelation == null) {
+                    throw new BusinessException(404, "未找到学生班级信息");
+                }
+                Stream<Long> longStream = classExperimentClassRelationMapper.selectList(
+                                new LambdaQueryWrapper<ClassExperimentClassRelation>()
+                                        .eq(ClassExperimentClassRelation::getClassCode, studentClassRelation.getClassCode()))
+                        .stream()
+                        .map(ClassExperimentClassRelation::getClassExperimentId);
                 classExperimentWrapper.in(ClassExperiment::getId, longStream);
                 classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
                 classExperimentWrapper.eq(ClassExperiment::getExperimentId, experimentId);
+                classExperimentWrapper.orderByDesc(ClassExperiment::getStartTime);
+                classExperimentWrapper.last("LIMIT 1");
             }else {
                 classExperimentWrapper.eq(ClassExperiment::getId, studentProcedure.getClassExperimentId());
             }

--- a/src/main/java/com/example/demo/service/StudentProcedureSubmissionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureSubmissionService.java
@@ -228,17 +228,17 @@ public class StudentProcedureSubmissionService {
             throw new BusinessException(404, "班级实验不存在");
         }
 
-        // 2. 获取关联的班级列表（使用第一个班级）
-        List<String> classCodes = classExperimentClassRelationService.getClassCodesByExperimentId(classExperimentId);
-        if (classCodes == null || classCodes.isEmpty()) {
-            throw new BusinessException(404, "班级实验未关联任何班级");
+        // 2. 按课次精确查询提交，兼容历史数据回退
+        List<StudentExperimentalProcedure> submissions = listSubmissionsByClassExperimentId(classExperimentId, classExperiment);
+
+        // 3. 按提交状态过滤
+        if (submissionStatus != null) {
+            submissions = submissions.stream()
+                    .filter(item -> submissionStatus.equals(item.getIsGraded()))
+                    .toList();
         }
-        String classCode = classCodes.get(0);
 
-        Long experimentId = Long.parseLong(classExperiment.getExperimentId());
-
-        // 3. 调用原有方法
-        return getCourseSubmissions(classCode, experimentId, submissionStatus);
+        return submissions.stream().map(this::buildResponse).collect(Collectors.toList());
     }
 
     private List<StudentExperimentalProcedure> listSubmissionsByClassExperimentId(Long classExperimentId,
@@ -260,15 +260,18 @@ public class StudentProcedureSubmissionService {
             throw new BusinessException(404, "班级实验未关联任何班级");
         }
 
+        // 仅在当前课次没有精确落库数据时，才回退到历史兼容查询
         Long experimentId = Long.parseLong(classExperiment.getExperimentId());
         LambdaQueryWrapper<StudentExperimentalProcedure> fallbackQuery = new LambdaQueryWrapper<>();
         fallbackQuery.eq(StudentExperimentalProcedure::getExperimentId, experimentId)
                 .in(StudentExperimentalProcedure::getClassCode, classCodes)
+                .isNull(StudentExperimentalProcedure::getClassExperimentId)
                 .orderByDesc(StudentExperimentalProcedure::getCreatedTime);
         List<StudentExperimentalProcedure> fallbackMatches = studentExperimentalProcedureMapper.selectList(fallbackQuery);
         fallbackMatches.forEach(item -> submissionMap.put(item.getId(), item));
         return new ArrayList<>(submissionMap.values());
     }
+
 
     @Data
     @AllArgsConstructor

--- a/src/main/java/com/example/demo/service/StudentProcedureSubmissionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureSubmissionService.java
@@ -5,9 +5,12 @@ import com.example.demo.exception.BusinessException;
 import com.example.demo.mapper.ClassExperimentMapper;
 import com.example.demo.mapper.StudentExperimentalProcedureMapper;
 import com.example.demo.mapper.UserMapper;
+import com.example.demo.pojo.entity.ClassExperiment;
 import com.example.demo.pojo.entity.StudentExperimentalProcedure;
 import com.example.demo.pojo.entity.User;
 import com.example.demo.pojo.response.StudentProcedureSubmissionResponse;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,7 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -31,6 +37,7 @@ public class StudentProcedureSubmissionService {
     private final UserMapper userMapper;
     private final ClassExperimentMapper classExperimentMapper;
     private final ClassExperimentClassRelationService classExperimentClassRelationService;
+    private final StudentProcedureCompletionService studentProcedureCompletionService;
 
     /** 提交状态常量 */
     public static final Integer STATUS_NOT_GRADED = 0;      // 未评分
@@ -131,6 +138,52 @@ public class StudentProcedureSubmissionService {
     }
 
     /**
+     * 按课次重新执行机器自动批改
+     *
+     * @param classExperimentId 班级实验ID
+     * @return 重批结果统计
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public ReAutoGradeSummary reAutoGradeByClassExperimentId(Long classExperimentId) {
+        ClassExperiment classExperiment = classExperimentMapper.selectById(classExperimentId);
+        if (classExperiment == null) {
+            throw new BusinessException(404, "班级实验不存在");
+        }
+
+        List<StudentExperimentalProcedure> submissions = listSubmissionsByClassExperimentId(classExperimentId, classExperiment);
+        ReAutoGradeSummary summary = new ReAutoGradeSummary();
+        summary.setScannedCount(submissions.size());
+
+        for (StudentExperimentalProcedure submission : submissions) {
+            Integer gradeStatus = submission.getIsGraded();
+            if (STATUS_TEACHER_GRADED.equals(gradeStatus)) {
+                summary.setSkippedTeacherGradedCount(summary.getSkippedTeacherGradedCount() + 1);
+                continue;
+            }
+
+            StudentProcedureCompletionService.AutoGradeExecutionResult result =
+                    studentProcedureCompletionService.autoGradeExistingDataCollectionSubmission(submission.getId());
+
+            if (result.isSuccess()) {
+                summary.setReAutoGradedCount(summary.getReAutoGradedCount() + 1);
+            } else if (result.isSkipped()) {
+                summary.setSkippedUnsupportedCount(summary.getSkippedUnsupportedCount() + 1);
+            } else {
+                summary.setFailedCount(summary.getFailedCount() + 1);
+            }
+        }
+
+        log.info("课次 {} 重新机器批改完成，扫描：{}，成功：{}，跳过人工：{}，跳过其他：{}，失败：{}",
+                classExperimentId,
+                summary.getScannedCount(),
+                summary.getReAutoGradedCount(),
+                summary.getSkippedTeacherGradedCount(),
+                summary.getSkippedUnsupportedCount(),
+                summary.getFailedCount());
+        return summary;
+    }
+
+    /**
      * 构建响应对象
      */
     private StudentProcedureSubmissionResponse buildResponse(StudentExperimentalProcedure submission) {
@@ -170,8 +223,7 @@ public class StudentProcedureSubmissionService {
             Long classExperimentId, Integer submissionStatus) {
 
         // 1. 查询班级实验信息
-        com.example.demo.pojo.entity.ClassExperiment classExperiment =
-                classExperimentMapper.selectById(classExperimentId);
+        ClassExperiment classExperiment = classExperimentMapper.selectById(classExperimentId);
         if (classExperiment == null) {
             throw new BusinessException(404, "班级实验不存在");
         }
@@ -187,5 +239,47 @@ public class StudentProcedureSubmissionService {
 
         // 3. 调用原有方法
         return getCourseSubmissions(classCode, experimentId, submissionStatus);
+    }
+
+    private List<StudentExperimentalProcedure> listSubmissionsByClassExperimentId(Long classExperimentId,
+                                                                                   ClassExperiment classExperiment) {
+        LinkedHashMap<Long, StudentExperimentalProcedure> submissionMap = new LinkedHashMap<>();
+
+        LambdaQueryWrapper<StudentExperimentalProcedure> exactQuery = new LambdaQueryWrapper<>();
+        exactQuery.eq(StudentExperimentalProcedure::getClassExperimentId, classExperimentId)
+                .orderByDesc(StudentExperimentalProcedure::getCreatedTime);
+        List<StudentExperimentalProcedure> exactMatches = studentExperimentalProcedureMapper.selectList(exactQuery);
+        exactMatches.forEach(item -> submissionMap.put(item.getId(), item));
+
+        if (!submissionMap.isEmpty()) {
+            return new ArrayList<>(submissionMap.values());
+        }
+
+        List<String> classCodes = classExperimentClassRelationService.getClassCodesByExperimentId(classExperimentId);
+        if (classCodes == null || classCodes.isEmpty()) {
+            throw new BusinessException(404, "班级实验未关联任何班级");
+        }
+
+        Long experimentId = Long.parseLong(classExperiment.getExperimentId());
+        LambdaQueryWrapper<StudentExperimentalProcedure> fallbackQuery = new LambdaQueryWrapper<>();
+        fallbackQuery.eq(StudentExperimentalProcedure::getExperimentId, experimentId)
+                .in(StudentExperimentalProcedure::getClassCode, classCodes)
+                .orderByDesc(StudentExperimentalProcedure::getCreatedTime);
+        List<StudentExperimentalProcedure> fallbackMatches = studentExperimentalProcedureMapper.selectList(fallbackQuery);
+        fallbackMatches.forEach(item -> submissionMap.put(item.getId(), item));
+        return new ArrayList<>(submissionMap.values());
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ReAutoGradeSummary {
+        private int scannedCount;
+        private int reAutoGradedCount;
+        private int skippedTeacherGradedCount;
+        private int skippedUnsupportedCount;
+        private int failedCount;
+
+        public ReAutoGradeSummary() {
+        }
     }
 }

--- a/src/main/java/com/example/demo/service/TeacherClassroomQuizService.java
+++ b/src/main/java/com/example/demo/service/TeacherClassroomQuizService.java
@@ -3,10 +3,14 @@ package com.example.demo.service;
 import com.baomidou.mybatisplus.extension.service.IService;
 import com.example.demo.pojo.entity.ClassroomQuiz;
 import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequest;
+import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequestV2;
 import com.example.demo.pojo.response.ClassroomQuizHistoryResponse;
+import com.example.demo.pojo.response.ClassroomQuizHistoryResponseV2;
 import com.example.demo.pojo.response.ClassroomQuizStatisticsResponse;
 import com.example.demo.pojo.response.StudentClassroomQuizDetailResponse;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * 教师课堂小测服务
@@ -15,49 +19,64 @@ import org.springframework.stereotype.Service;
 public interface TeacherClassroomQuizService extends IService<ClassroomQuiz> {
 
     /**
-     * 创建课堂小测
-     *
-     * @param request 创建请求
-     * @return 小测ID
+     * 创建课堂小测（新版）
      */
-    Long createClassroomQuiz(CreateClassroomQuizRequest request);
+    Long createClassroomQuiz(CreateClassroomQuizRequestV2 request);
 
     /**
-     * 开始小测
-     *
-     * @param quizId 小测ID
+     * 创建课堂小测（旧版）
      */
+    @Deprecated
+    default Long createClassroomQuiz(CreateClassroomQuizRequest request) {
+        return createClassroomQuiz(CreateClassroomQuizRequestV2.fromLegacy(request));
+    }
+
     void startQuiz(Long quizId);
 
-    /**
-     * 结束小测
-     *
-     * @param quizId 小测ID
-     */
     void endQuiz(Long quizId);
 
-    /**
-     * 查询小测统计
-     *
-     * @param quizId 小测ID
-     * @return 统计信息
-     */
     ClassroomQuizStatisticsResponse getQuizStatistics(Long quizId);
 
-    /**
-     * 查询指定学生答题详情
-     *
-     * @param quizId          小测ID
-     * @param studentUsername 学生用户名
-     * @return 答题详情
-     */
     StudentClassroomQuizDetailResponse getStudentAnswerDetail(Long quizId, String studentUsername);
 
-    /**
-     * 查询教师发布的历史小测列表
-     *
-     * @param classExperimentId 班级实验ID（可选，不传则查询所有）
-     * @return 历史小测列表
-     */
-    java.util.List<ClassroomQuizHistoryResponse> getHistoryQuizzes(Long classExperimentId);
+    List<ClassroomQuizHistoryResponseV2> getHistoryQuizzes(Long classExperimentId);
+
+    @Deprecated
+    default List<ClassroomQuizHistoryResponse> getHistoryQuizzesLegacy(Long classExperimentId) {
+        return getHistoryQuizzes(classExperimentId).stream().map(item -> {
+            ClassroomQuizHistoryResponse legacy = new ClassroomQuizHistoryResponse();
+            legacy.setId(item.getId());
+            legacy.setClassExperimentId(item.getClassExperimentId());
+            legacy.setQuizTitle(item.getQuizTitle());
+            legacy.setQuizDescription(item.getQuizDescription());
+            legacy.setQuizTimeLimit(item.getQuizTimeLimit());
+            legacy.setStatus(item.getStatus());
+            legacy.setStartTime(item.getStartTime());
+            legacy.setEndTime(item.getEndTime());
+            legacy.setCreatedBy(item.getCreatedBy());
+            legacy.setCreatedTime(item.getCreatedTime());
+            legacy.setProcedureTopic(item.getProcedureTopic() == null ? null : toLegacy(item.getProcedureTopic()));
+            return legacy;
+        }).toList();
+    }
+
+    private static ClassroomQuizHistoryResponse.ProcedureTopicInfo toLegacy(ClassroomQuizHistoryResponseV2.ProcedureTopicInfo item) {
+        ClassroomQuizHistoryResponse.ProcedureTopicInfo legacy = new ClassroomQuizHistoryResponse.ProcedureTopicInfo();
+        legacy.setIsRandom(item.getIsRandom());
+        legacy.setNumber(item.getNumber());
+        legacy.setTags(item.getTags());
+        legacy.setTopicTypes(item.getTopicTypes());
+        legacy.setSelectedTopicCount(item.getSelectedTopicCount());
+        legacy.setTopics(item.getTopics() == null ? null : item.getTopics().stream().map(topic -> {
+            ClassroomQuizHistoryResponse.ProcedureTopicInfo.TopicInfo legacyTopic = new ClassroomQuizHistoryResponse.ProcedureTopicInfo.TopicInfo();
+            legacyTopic.setTopicId(topic.getTopicId());
+            legacyTopic.setNumber(topic.getNumber());
+            legacyTopic.setType(topic.getType());
+            legacyTopic.setContent(topic.getContent());
+            legacyTopic.setChoices(topic.getChoices());
+            legacyTopic.setCorrectAnswer(topic.getCorrectAnswer());
+            return legacyTopic;
+        }).toList());
+        return legacy;
+    }
 }

--- a/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
@@ -360,6 +360,10 @@ public class StudentClassroomQuizServiceImpl implements StudentClassroomQuizServ
                 if (!tagIdList.isEmpty()) {
                     LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
                     tagWrapper.in(TopicTagMap::getTagId, tagIdList);
+                    tagWrapper.groupBy(TopicTagMap::getTopicId);
+                    if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
+                        tagWrapper.having("COUNT(DISTINCT tag_id) >= " + tagIdList.size());
+                    }
                     List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
 
                     if (!topicTagMaps.isEmpty()) {
@@ -383,7 +387,7 @@ public class StudentClassroomQuizServiceImpl implements StudentClassroomQuizServ
                                 }
                             }
 
-                            topicWrapper.last("ORDER BY RAND() LIMIT "+ procedureTopic.getNumber());
+                            topicWrapper.last("ORDER BY RAND() LIMIT " + procedureTopic.getNumber());
                             return topicMapper.selectList(topicWrapper);
                         }
                     }

--- a/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
@@ -111,6 +111,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
             throw new BusinessException(400,"随机抽题必须携带标签");
         }
         procedureTopic.setTags(s);
+        procedureTopic.setTagMatchAll(Boolean.TRUE.equals(request.getTagMatchAll()));
         procedureTopic.setTopicTypes(joinIntegerListToString(request.getTopicTypes()));
         procedureTopic.setCreatedTime(LocalDateTime.now());
         procedureTopic.setIsDeleted(false);
@@ -466,6 +467,10 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
                 if (!tagIdList.isEmpty()) {
                     LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
                     tagWrapper.in(TopicTagMap::getTagId, tagIdList);
+                    tagWrapper.groupBy(TopicTagMap::getTopicId);
+                    if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
+                        tagWrapper.having("COUNT(DISTINCT tag_id) >= " + tagIdList.size());
+                    }
                     List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
 
                     if (!topicTagMaps.isEmpty()) {

--- a/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
@@ -6,7 +6,9 @@ import com.example.demo.exception.BusinessException;
 import com.example.demo.mapper.*;
 import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequest;
+import com.example.demo.pojo.request.teacher.CreateClassroomQuizRequestV2;
 import com.example.demo.pojo.response.ClassroomQuizHistoryResponse;
+import com.example.demo.pojo.response.ClassroomQuizHistoryResponseV2;
 import com.example.demo.pojo.response.ClassroomQuizStatisticsResponse;
 import com.example.demo.pojo.response.StudentClassroomQuizDetailResponse;
 import com.example.demo.service.ClassExperimentClassRelationService;
@@ -49,7 +51,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    public Long createClassroomQuiz(CreateClassroomQuizRequest request) {
+    public Long createClassroomQuiz(CreateClassroomQuizRequestV2 request) {
         log.info("创建课堂小测，请求: {}", request);
 
         // 验证班级实验ID是否存在
@@ -83,7 +85,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
     /**
      * 为课堂小测创建题库配置
      */
-    private Long createProcedureTopicForQuiz(CreateClassroomQuizRequest request) {
+    private Long createProcedureTopicForQuiz(CreateClassroomQuizRequestV2 request) {
         // 验证题库配置字段
         if (request.getIsRandom() == null) {
             throw new BusinessException(400, "是否随机抽取不能为空");
@@ -681,7 +683,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
     }
 
     @Override
-    public List<ClassroomQuizHistoryResponse> getHistoryQuizzes(Long classExperimentId) {
+    public List<ClassroomQuizHistoryResponseV2> getHistoryQuizzes(Long classExperimentId) {
         log.info("查询教师历史小测列表，班级实验ID: {}", classExperimentId);
 
         // 获取当前教师用户名
@@ -703,7 +705,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
 
         // 转换为响应对象
         return quizzes.stream().map(quiz -> {
-            ClassroomQuizHistoryResponse response = new ClassroomQuizHistoryResponse();
+            ClassroomQuizHistoryResponseV2 response = new ClassroomQuizHistoryResponseV2();
             response.setId(quiz.getId());
             response.setClassExperimentId(quiz.getClassExperimentId());
             response.setQuizTitle(quiz.getQuizTitle());
@@ -718,22 +720,20 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
             // 查询题库配置信息
             ProcedureTopic procedureTopic = procedureTopicMapper.selectById(quiz.getProcedureTopicId());
             if (procedureTopic != null) {
-                // 非随机模式下，查询选定的题���数量
                 Integer selectedTopicCount = null;
                 if (!Boolean.TRUE.equals(procedureTopic.getIsRandom())) {
                     LambdaQueryWrapper<ProcedureTopicMap> mapWrapper = new LambdaQueryWrapper<>();
                     mapWrapper.eq(ProcedureTopicMap::getProcedureTopicId, procedureTopic.getId());
                     selectedTopicCount = Math.toIntExact(procedureTopicMapMapper.selectCount(mapWrapper));
                 }
-                ClassroomQuizHistoryResponse.ProcedureTopicInfo procedureTopicInfo =
-                        ClassroomQuizHistoryResponse.ProcedureTopicInfo.fromEntity(procedureTopic, selectedTopicCount);
+                ClassroomQuizHistoryResponseV2.ProcedureTopicInfo procedureTopicInfo =
+                        ClassroomQuizHistoryResponseV2.ProcedureTopicInfo.fromEntity(procedureTopic, selectedTopicCount);
 
-                // 查询题目列表
                 List<Topic> topics = getTopicsForQuiz(quiz, procedureTopic);
-                List<ClassroomQuizHistoryResponse.ProcedureTopicInfo.TopicInfo> topicInfos = topics.stream()
+                List<ClassroomQuizHistoryResponseV2.ProcedureTopicInfo.TopicInfo> topicInfos = topics.stream()
                         .map(topic -> {
-                            ClassroomQuizHistoryResponse.ProcedureTopicInfo.TopicInfo topicInfo =
-                                new ClassroomQuizHistoryResponse.ProcedureTopicInfo.TopicInfo();
+                            ClassroomQuizHistoryResponseV2.ProcedureTopicInfo.TopicInfo topicInfo =
+                                new ClassroomQuizHistoryResponseV2.ProcedureTopicInfo.TopicInfo();
                             topicInfo.setTopicId(topic.getId());
                             topicInfo.setNumber(topic.getNumber());
                             topicInfo.setType(topic.getType());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,6 @@ spring:
       max-file-size: 500MB
       max-request-size: 500MB
 
-
-
 mybatis-plus:
   configuration:
     map-underscore-to-camel-case: true


### PR DESCRIPTION
## Summary
- 修复学生实验步骤班级实验标识落库与查询逻辑，补齐 `classExperimentId` 的保存和读取链路
- 为课堂小测新增标签匹配模式参数 `tagMatchAll`，支持“单个符合”与“全符合”两种筛题方式
- 对会影响前端联调的课堂小测接口做版本拆分，保留旧版兼容接口并新增新版接口

## 修改了什么内容
- 补齐学生实验步骤在多种提交流程下的 `classExperimentId` 落库逻辑
- 优化学生步骤查询时的班级实验定位逻辑，兼容历史数据缺少 `classExperimentId` 的情况
- 为课堂小测题库配置新增 `tagMatchAll` 字段，并同步教师端、学生端筛题逻辑
- 为教师端课堂小测创建与历史查询接口新增版本化请求/响应对象
- 在旧版课堂小测接口注释中标注“旧版”，并通过 `@Deprecated` 保留兼容入口

## 添加了什么接口
- `POST /api/teacher/classroom-quiz/v2`
  - 新版创建课堂小测接口
  - 支持 `tagMatchAll` 参数
- `GET /api/teacher/classroom-quiz/history/v2`
  - 新版教师历史小测列表接口
  - 返回包含 `tagMatchAll` 的新版响应结构

## 保留的旧版接口
- `POST /api/teacher/classroom-quiz`
  - 旧版创建课堂小测接口
  - 保持兼容，不支持标签全匹配能力
- `GET /api/teacher/classroom-quiz/history`
  - 旧版教师历史小测列表接口
  - 保持兼容，不返回标签全匹配字段

## Test plan
- [x] 执行 `./mvnw -q -DskipTests compile`，确认项目编译通过
- [ ] 联调旧版课堂小测创建与历史接口，确认旧前端兼容
- [ ] 联调新版课堂小测创建与历史接口，确认 `tagMatchAll` 生效
- [ ] 验证随机抽题在“单个符合 / 全符合”两种模式下返回结果符合预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)