### PR TITLE
统一随机抽题标签匹配逻辑

### DIFF
--- a/src/main/java/com/example/demo/mapper/TopicTagMapMapper.java
+++ b/src/main/java/com/example/demo/mapper/TopicTagMapMapper.java
@@ -15,6 +15,21 @@ import java.util.List;
 public interface TopicTagMapMapper extends BaseMapper<TopicTagMap> {
 
     /**
+     * 查询命中任一指定标签的题目ID
+     *
+     * @param tagIds 标签ID列表
+     * @return 题目ID列表
+     */
+    @Select("<script>" +
+            "SELECT DISTINCT topic_id FROM topic_tag_map " +
+            "WHERE tag_id IN " +
+            "<foreach collection='tagIds' item='tagId' open='(' separator=',' close=')'>" +
+            "    #{tagId}" +
+            "</foreach>" +
+            "</script>")
+    List<Long> selectDistinctTopicIdsByAnyTags(@Param("tagIds") List<Long> tagIds);
+
+    /**
      * 查询包含所有指定标签的题目ID
      *
      * @param tagIds 标签ID列表

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertTopicProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertTopicProcedureRequest.java
@@ -77,6 +77,9 @@ public class InsertTopicProcedureRequest {
      * @return 转换后的字符串
      */
     public String getTopicTagsToString() {
+        if (topicTags == null || topicTags.isEmpty()) {
+            return null;
+        }
         StringBuilder tags = new StringBuilder();
         for (int i = 0; i < topicTags.size(); i++) {
             tags.append(topicTags.get(i));

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -41,7 +41,7 @@ public class ClassStudentProcedureQueryService {
     private final DataCollectionMapper dataCollectionMapper;
     private final ProcedureTopicMapper procedureTopicMapper;
     private final TopicMapper topicMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final ClassExperimentMapper classExperimentMapper;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
@@ -716,7 +716,7 @@ public class ClassStudentProcedureQueryService {
                     .toList();
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                    List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
@@ -804,7 +804,7 @@ public class ClassStudentProcedureQueryService {
                 .toList();
 
             if (!tagIdList.isEmpty()) {
-                List<Long> topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                 if (!topicIds.isEmpty()) {
                     LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -804,17 +804,7 @@ public class ClassStudentProcedureQueryService {
                 .toList();
 
             if (!tagIdList.isEmpty()) {
-                String sql = "SELECT topic_id FROM topic_tag_map " +
-                            "WHERE tag_id IN (" + tagIdList.stream().map(String::valueOf).collect(Collectors.joining(",")) + ") " +
-                            "GROUP BY topic_id " +
-                            "HAVING COUNT(DISTINCT tag_id) = " + tagIdList.size();
-
-                List<Long> topicIds = topicTagMapMapper.selectList(
-                    new LambdaQueryWrapper<TopicTagMap>().apply(sql)
-                ).stream()
-                .map(TopicTagMap::getTopicId)
-                .distinct()
-                .collect(Collectors.toList());
+                List<Long> topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
 
                 if (!topicIds.isEmpty()) {
                     LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -40,7 +40,7 @@ public class StudentProcedureQueryService {
     private final DataCollectionMapper dataCollectionMapper;
     private final ProcedureTopicMapper procedureTopicMapper;
     private final TopicMapper topicMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final DownloadService downloadService;
     private final ClassExperimentMapper classExperimentMapper;
@@ -520,8 +520,7 @@ public class StudentProcedureQueryService {
                     .toList();
 
                 if (!tagIdList.isEmpty()) {
-                    // 查询包含所有指定标签的题目（AND逻辑）
-                    List<Long> topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                    List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
@@ -747,8 +746,7 @@ public class StudentProcedureQueryService {
                 .toList();
 
             if (!tagIdList.isEmpty()) {
-                // 查询包含所有指定标签的题目（AND逻辑）
-                List<Long> topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                 if (!topicIds.isEmpty()) {
                     LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -250,7 +250,7 @@ public class TeacherProcedureCreationService {
         // 自动计算步骤号
         Integer newNumber = getMaxProcedureNumber(request.getExperimentId()) + 1;
 
-        // 1. 先创���步骤实体
+        // 1. 先创步骤实体
         ExperimentalProcedure procedure = new ExperimentalProcedure();
         procedure.setExperimentId(request.getExperimentId());
         procedure.setNumber(newNumber);

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -797,8 +797,8 @@ public class TeacherProcedureCreationService {
         procedureTopic.setIsRandom(request.getIsRandom());
         procedureTopic.setNumber(request.getTopicNumber());
         String s = request.getTopicTagsToString();
-        if(s.isEmpty() && request.getIsRandom()){
-            throw new BusinessException(400,"随机抽题必须携带标签");
+        if (Boolean.TRUE.equals(request.getIsRandom()) && (s == null || s.isEmpty())) {
+            throw new BusinessException(400, "随机抽题必须携带标签");
         }
         procedureTopic.setTags(s);
         procedureTopic.setTopicTypes(request.getTopicTypesToString());

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -274,8 +274,8 @@ public class TeacherProcedureCreationService {
         procedureTopic.setIsRandom(request.getIsRandom());
         procedureTopic.setNumber(request.getTopicNumber());
         String s = joinTopicTags(request.getTopicTags());
-        if(s.isEmpty() && request.getIsRandom()){
-            throw new BusinessException(400,"随机抽题必须携带标签");
+        if (Boolean.TRUE.equals(request.getIsRandom()) && (s == null || s.isEmpty())) {
+            throw new BusinessException(400, "随机抽题必须携带标签");
         }
         procedureTopic.setTags(s);
         procedureTopic.setTopicTypes(joinTopicTypes(request.getTopicTypes()));
@@ -507,8 +507,8 @@ public class TeacherProcedureCreationService {
                 procedureTopic.setIsRandom(request.getIsRandom());
                 procedureTopic.setNumber(request.getTopicNumber());
                 String s = joinTopicTags(request.getTopicTags());
-                if(s.isEmpty() && request.getIsRandom()){
-                    throw new BusinessException(400,"随机抽题必须携带标签");
+                if (Boolean.TRUE.equals(request.getIsRandom()) && (s == null || s.isEmpty())) {
+                    throw new BusinessException(400, "随机抽题必须携带标签");
                 }
                 procedureTopic.setTags(s);
                 procedureTopic.setTopicTypes(joinTopicTypes(request.getTopicTypes()));
@@ -869,7 +869,7 @@ public class TeacherProcedureCreationService {
      */
     private String joinTopicTags(List<Long> topicTags) {
         if (topicTags == null || topicTags.isEmpty()) {
-            throw new BusinessException(400,"至少添加一个标签");
+            return null;
         }
 
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
@@ -373,35 +373,26 @@ public class TeacherProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
-                    tagWrapper.in(TopicTagMap::getTagId, tagIdList);
-                    List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
+                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
 
-                    if (!topicTagMaps.isEmpty()) {
-                        List<Long> topicIds = topicTagMaps.stream()
-                            .map(TopicTagMap::getTopicId)
-                            .distinct()
-                            .collect(Collectors.toList());
+                    if (!topicIds.isEmpty()) {
+                        LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
+                        topicWrapper.in(Topic::getId, topicIds);
 
-                        if (!topicIds.isEmpty()) {
-                            LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
-                            topicWrapper.in(Topic::getId, topicIds);
-
-                            // 添加题目类型过滤
-                            if (timedQuiz.getTopicTypes() != null && !timedQuiz.getTopicTypes().isEmpty()) {
-                                String[] typeArray = timedQuiz.getTopicTypes().split(",");
-                                List<Integer> types = Arrays.stream(typeArray)
-                                    .filter(s -> s != null && !s.isEmpty())
-                                    .map(Integer::parseInt)
-                                    .collect(Collectors.toList());
-                                if (!types.isEmpty()) {
-                                    topicWrapper.in(Topic::getType, types);
-                                }
+                        // 添加题目类型过滤
+                        if (timedQuiz.getTopicTypes() != null && !timedQuiz.getTopicTypes().isEmpty()) {
+                            String[] typeArray = timedQuiz.getTopicTypes().split(",");
+                            List<Integer> types = Arrays.stream(typeArray)
+                                .filter(s -> s != null && !s.isEmpty())
+                                .map(Integer::parseInt)
+                                .collect(Collectors.toList());
+                            if (!types.isEmpty()) {
+                                topicWrapper.in(Topic::getType, types);
                             }
-
-                            topicWrapper.orderByAsc(Topic::getNumber);
-                            return topicMapper.selectList(topicWrapper);
                         }
+
+                        topicWrapper.orderByAsc(Topic::getNumber);
+                        return topicMapper.selectList(topicWrapper);
                     }
                 }
             }

--- a/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
@@ -6,10 +6,10 @@ import com.example.demo.mapper.DataCollectionMapper;
 import com.example.demo.mapper.ProcedureTopicMapMapper;
 import com.example.demo.mapper.ProcedureTopicMapper;
 import com.example.demo.mapper.TopicMapper;
+import com.example.demo.service.TopicTagMatchService;
 import com.example.demo.mapper.VideoFileMapper;
 import com.example.demo.mapper.TagMapper;
 import com.example.demo.mapper.TimedQuizProcedureMapper;
-import com.example.demo.mapper.TopicTagMapMapper;
 import com.example.demo.pojo.entity.ClassExperiment;
 import com.example.demo.pojo.entity.DataCollection;
 import com.example.demo.pojo.entity.ExperimentalProcedure;
@@ -19,7 +19,6 @@ import com.example.demo.pojo.entity.Topic;
 import com.example.demo.pojo.entity.VideoFile;
 import com.example.demo.pojo.entity.Tag;
 import com.example.demo.pojo.entity.TimedQuizProcedure;
-import com.example.demo.pojo.entity.TopicTagMap;
 import com.example.demo.pojo.response.TeacherDataCollectionProcedureDetailResponse;
 import com.example.demo.pojo.response.TeacherProcedureDetailResponse;
 import com.example.demo.pojo.response.TeacherTopicProcedureDetailResponse;
@@ -55,7 +54,7 @@ public class TeacherProcedureQueryService {
     private final ClassExperimentMapper classExperimentMapper;
     private final TagMapper tagMapper;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
 
     /**
      * 查询步骤详情(包含类型特定的完整信息)
@@ -373,7 +372,7 @@ public class TeacherProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
+                    List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
@@ -1185,35 +1185,26 @@ public class TeacherStudentProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
-                    tagWrapper.in(TopicTagMap::getTagId, tagIdList);
-                    List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
+                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
 
-                    if (!topicTagMaps.isEmpty()) {
-                        List<Long> topicIds = topicTagMaps.stream()
-                            .map(TopicTagMap::getTopicId)
-                            .distinct()
-                            .collect(Collectors.toList());
+                    if (!topicIds.isEmpty()) {
+                        LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
+                        topicWrapper.in(Topic::getId, topicIds);
 
-                        if (!topicIds.isEmpty()) {
-                            LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
-                            topicWrapper.in(Topic::getId, topicIds);
-
-                            // 添加题目类型过滤
-                            if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
-                                String[] typeArray = procedureTopic.getTopicTypes().split(",");
-                                List<Integer> types = Arrays.stream(typeArray)
-                                    .filter(s -> s != null && !s.isEmpty())
-                                    .map(Integer::parseInt)
-                                    .collect(Collectors.toList());
-                                if (!types.isEmpty()) {
-                                    topicWrapper.in(Topic::getType, types);
-                                }
+                        // 添加题目类型过滤
+                        if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
+                            String[] typeArray = procedureTopic.getTopicTypes().split(",");
+                            List<Integer> types = Arrays.stream(typeArray)
+                                .filter(s -> s != null && !s.isEmpty())
+                                .map(Integer::parseInt)
+                                .collect(Collectors.toList());
+                            if (!types.isEmpty()) {
+                                topicWrapper.in(Topic::getType, types);
                             }
-
-                            topicWrapper.orderByAsc(Topic::getNumber);
-                            return topicMapper.selectList(topicWrapper);
                         }
+
+                        topicWrapper.orderByAsc(Topic::getNumber);
+                        return topicMapper.selectList(topicWrapper);
                     }
                 }
             }
@@ -1969,35 +1960,26 @@ public class TeacherStudentProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
-                    tagWrapper.in(TopicTagMap::getTagId, tagIdList);
-                    List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
+                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
 
-                    if (!topicTagMaps.isEmpty()) {
-                        List<Long> topicIds = topicTagMaps.stream()
-                            .map(TopicTagMap::getTopicId)
-                            .distinct()
-                            .collect(Collectors.toList());
+                    if (!topicIds.isEmpty()) {
+                        LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
+                        topicWrapper.in(Topic::getId, topicIds);
 
-                        if (!topicIds.isEmpty()) {
-                            LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
-                            topicWrapper.in(Topic::getId, topicIds);
-
-                            // 添加题目类型过滤
-                            if (timedQuiz.getTopicTypes() != null && !timedQuiz.getTopicTypes().isEmpty()) {
-                                String[] typeArray = timedQuiz.getTopicTypes().split(",");
-                                List<Integer> types = Arrays.stream(typeArray)
-                                    .filter(s -> s != null && !s.isEmpty())
-                                    .map(Integer::parseInt)
-                                    .collect(Collectors.toList());
-                                if (!types.isEmpty()) {
-                                    topicWrapper.in(Topic::getType, types);
-                                }
+                        // 添加题目类型过滤
+                        if (timedQuiz.getTopicTypes() != null && !timedQuiz.getTopicTypes().isEmpty()) {
+                            String[] typeArray = timedQuiz.getTopicTypes().split(",");
+                            List<Integer> types = Arrays.stream(typeArray)
+                                .filter(s -> s != null && !s.isEmpty())
+                                .map(Integer::parseInt)
+                                .collect(Collectors.toList());
+                            if (!types.isEmpty()) {
+                                topicWrapper.in(Topic::getType, types);
                             }
-
-                            topicWrapper.orderByAsc(Topic::getNumber);
-                            return topicMapper.selectList(topicWrapper);
                         }
+
+                        topicWrapper.orderByAsc(Topic::getNumber);
+                        return topicMapper.selectList(topicWrapper);
                     }
                 }
             }

--- a/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
@@ -9,6 +9,7 @@ import com.example.demo.mapper.*;
 import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.response.*;
 import com.example.demo.util.DataCollectionDataUtil;
+import com.example.demo.service.TopicTagMatchService;
 import com.example.demo.util.TopicAnswerContractUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,7 @@ public class TeacherStudentProcedureQueryService {
     private final StudentProcedureAttachmentMapper studentProcedureAttachmentMapper;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final TopicMapper topicMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
     private final ProcedureTopicMapper procedureTopicMapper;
     private final DataCollectionMapper dataCollectionMapper;
     private final VideoFileMapper videoFileMapper;
@@ -1185,7 +1186,7 @@ public class TeacherStudentProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
+                    List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
@@ -1960,7 +1961,7 @@ public class TeacherStudentProcedureQueryService {
                     .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
+                    List<Long> topicIds = topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/TopicTagMatchService.java
+++ b/src/main/java/com/example/demo/service/TopicTagMatchService.java
@@ -1,0 +1,133 @@
+package com.example.demo.service;
+
+import com.example.demo.enums.TagType;
+import com.example.demo.exception.BusinessException;
+import com.example.demo.mapper.TagMapper;
+import com.example.demo.mapper.TopicTagMapMapper;
+import com.example.demo.pojo.entity.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 标签匹配服务
+ * 随机抽题时按标签类型分组：类型之间取交集，类型内取并集
+ */
+@Service
+@RequiredArgsConstructor
+public class TopicTagMatchService {
+
+    private final TagMapper tagMapper;
+    private final TopicTagMapMapper topicTagMapMapper;
+
+    /**
+     * 根据标签ID列表查询符合“类型间与、类型内或”规则的题目ID
+     *
+     * @param tagIds 标签ID列表
+     * @return 题目ID列表
+     */
+    public List<Long> selectTopicIdsByGroupedTags(List<Long> tagIds) {
+        if (tagIds == null || tagIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> distinctTagIds = tagIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        if (distinctTagIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Tag> tags = tagMapper.selectBatchIds(distinctTagIds);
+        if (tags == null || tags.isEmpty() || tags.size() != distinctTagIds.size()) {
+            throw new BusinessException(400, "部分标签不存在，无法完成随机抽题");
+        }
+
+        Map<TagType, List<Long>> tagIdsByType = buildTagIdsByType(tags);
+        if (tagIdsByType.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<Long> matchedTopicIds = null;
+        for (List<Long> sameTypeTagIds : tagIdsByType.values()) {
+            if (sameTypeTagIds == null || sameTypeTagIds.isEmpty()) {
+                continue;
+            }
+            List<Long> currentTypeTopicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(sameTypeTagIds);
+            if (currentTypeTopicIds == null || currentTypeTopicIds.isEmpty()) {
+                return Collections.emptyList();
+            }
+            if (matchedTopicIds == null) {
+                matchedTopicIds = new LinkedHashSet<>(currentTypeTopicIds);
+            } else {
+                matchedTopicIds.retainAll(currentTypeTopicIds);
+                if (matchedTopicIds.isEmpty()) {
+                    return Collections.emptyList();
+                }
+            }
+        }
+
+        if (matchedTopicIds == null || matchedTopicIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(matchedTopicIds);
+    }
+
+    public List<Long> selectTopicIdsByAllTags(List<Long> tagIds) {
+        if (tagIds == null || tagIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> distinctTagIds = tagIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        if (distinctTagIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Tag> tags = tagMapper.selectBatchIds(distinctTagIds);
+        if (tags == null || tags.isEmpty() || tags.size() != distinctTagIds.size()) {
+            throw new BusinessException(400, "部分标签不存在，无法完成随机抽题");
+        }
+        validateTags(tags);
+        return topicTagMapMapper.selectTopicIdsByAllTags(distinctTagIds, distinctTagIds.size());
+    }
+
+    private Map<TagType, List<Long>> buildTagIdsByType(List<Tag> tags) {
+        validateTags(tags);
+
+        Map<TagType, List<Long>> tagIdsByType = new LinkedHashMap<>();
+        for (Tag tag : tags) {
+            TagType tagType = TagType.fromCode(tag.getType());
+            tagIdsByType.computeIfAbsent(tagType, key -> new ArrayList<>()).add(tag.getId());
+        }
+        return tagIdsByType;
+    }
+
+    private void validateTags(List<Tag> tags) {
+        for (Tag tag : tags) {
+            if (tag == null || tag.getId() == null) {
+                throw new BusinessException(400, "标签数据异常，无法完成随机抽题");
+            }
+            if (tag.getType() == null || tag.getType().isEmpty()) {
+                throw new BusinessException(400, "标签类型缺失，无法完成随机抽题");
+            }
+            try {
+                TagType.fromCode(tag.getType());
+            } catch (IllegalArgumentException ex) {
+                throw new BusinessException(400, "标签类型非法，无法完成随机抽题");
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.demo.pojo.request.student.SubmitClassroomQuizAnswerRequest;
 import com.example.demo.pojo.response.StudentClassroomQuizDetailResponse;
 import com.example.demo.service.ClassExperimentClassRelationService;
 import com.example.demo.service.StudentClassroomQuizService;
+import com.example.demo.service.TopicTagMatchService;
 import com.example.demo.util.ClassroomQuizScorer;
 import com.example.demo.util.TopicAnswerContractUtil;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class StudentClassroomQuizServiceImpl implements StudentClassroomQuizServ
     private final ProcedureTopicMapper procedureTopicMapper;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final TopicMapper topicMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
     private final ClassroomQuizScorer classroomQuizScorer;
     private final ClassExperimentClassRelationService classExperimentClassRelationService;
     private final StudentClassRelationMapper studentClassRelationMapper;
@@ -358,12 +359,9 @@ public class StudentClassroomQuizServiceImpl implements StudentClassroomQuizServ
                         .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds;
-                    if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
-                        topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
-                    } else {
-                        topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
-                    }
+                    List<Long> topicIds = Boolean.TRUE.equals(procedureTopic.getTagMatchAll())
+                            ? topicTagMatchService.selectTopicIdsByAllTags(tagIdList)
+                            : topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/StudentClassroomQuizServiceImpl.java
@@ -358,38 +358,30 @@ public class StudentClassroomQuizServiceImpl implements StudentClassroomQuizServ
                         .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
-                    tagWrapper.in(TopicTagMap::getTagId, tagIdList);
-                    tagWrapper.groupBy(TopicTagMap::getTopicId);
+                    List<Long> topicIds;
                     if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
-                        tagWrapper.having("COUNT(DISTINCT tag_id) >= " + tagIdList.size());
+                        topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                    } else {
+                        topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
                     }
-                    List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
 
-                    if (!topicTagMaps.isEmpty()) {
-                        List<Long> topicIds = topicTagMaps.stream()
-                                .map(TopicTagMap::getTopicId)
-                                .distinct()
-                                .collect(Collectors.toList());
+                    if (!topicIds.isEmpty()) {
+                        LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
+                        topicWrapper.in(Topic::getId, topicIds);
 
-                        if (!topicIds.isEmpty()) {
-                            LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
-                            topicWrapper.in(Topic::getId, topicIds);
-
-                            if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
-                                String[] typeArray = procedureTopic.getTopicTypes().split(",");
-                                List<Integer> types = Arrays.stream(typeArray)
-                                        .filter(s -> s != null && !s.isEmpty())
-                                        .map(Integer::parseInt)
-                                        .collect(Collectors.toList());
-                                if (!types.isEmpty()) {
-                                    topicWrapper.in(Topic::getType, types);
-                                }
+                        if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
+                            String[] typeArray = procedureTopic.getTopicTypes().split(",");
+                            List<Integer> types = Arrays.stream(typeArray)
+                                    .filter(s -> s != null && !s.isEmpty())
+                                    .map(Integer::parseInt)
+                                    .collect(Collectors.toList());
+                            if (!types.isEmpty()) {
+                                topicWrapper.in(Topic::getType, types);
                             }
-
-                            topicWrapper.last("ORDER BY RAND() LIMIT " + procedureTopic.getNumber());
-                            return topicMapper.selectList(topicWrapper);
                         }
+
+                        topicWrapper.last("ORDER BY RAND() LIMIT " + procedureTopic.getNumber());
+                        return topicMapper.selectList(topicWrapper);
                     }
                 }
             }

--- a/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
@@ -13,6 +13,7 @@ import com.example.demo.pojo.response.ClassroomQuizStatisticsResponse;
 import com.example.demo.pojo.response.StudentClassroomQuizDetailResponse;
 import com.example.demo.service.ClassExperimentClassRelationService;
 import com.example.demo.service.TeacherClassroomQuizService;
+import com.example.demo.service.TopicTagMatchService;
 import com.example.demo.util.AnswerMapJSONUntil;
 import com.example.demo.util.SecurityUtil;
 import com.example.demo.util.TopicAnswerContractUtil;
@@ -42,7 +43,7 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
     private final ProcedureTopicMapper procedureTopicMapper;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
     private final TopicMapper topicMapper;
-    private final TopicTagMapMapper topicTagMapMapper;
+    private final TopicTagMatchService topicTagMatchService;
     private final ClassExperimentClassRelationService classExperimentClassRelationService;
     private final com.example.demo.util.ClassroomQuizScorer classroomQuizScorer;
     private final StudentClassRelationMapper studentClassRelationMapper;
@@ -467,12 +468,9 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
                         .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    List<Long> topicIds;
-                    if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
-                        topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
-                    } else {
-                        topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
-                    }
+                    List<Long> topicIds = Boolean.TRUE.equals(procedureTopic.getTagMatchAll())
+                            ? topicTagMatchService.selectTopicIdsByAllTags(tagIdList)
+                            : topicTagMatchService.selectTopicIdsByGroupedTags(tagIdList);
 
                     if (!topicIds.isEmpty()) {
                         LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();

--- a/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/TeacherClassroomQuizServiceImpl.java
@@ -109,8 +109,8 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
         procedureTopic.setIsRandom(request.getIsRandom());
         procedureTopic.setNumber(request.getTopicNumber());
         String s = joinListToString(request.getTopicTags());
-        if(s.isEmpty() && request.getIsRandom()){
-            throw new BusinessException(400,"随机抽题必须携带标签");
+        if (Boolean.TRUE.equals(request.getIsRandom()) && (s == null || s.isEmpty())) {
+            throw new BusinessException(400, "随机抽题必须携带标签");
         }
         procedureTopic.setTags(s);
         procedureTopic.setTagMatchAll(Boolean.TRUE.equals(request.getTagMatchAll()));
@@ -467,39 +467,31 @@ public class TeacherClassroomQuizServiceImpl extends ServiceImpl<ClassroomQuizMa
                         .collect(Collectors.toList());
 
                 if (!tagIdList.isEmpty()) {
-                    LambdaQueryWrapper<TopicTagMap> tagWrapper = new LambdaQueryWrapper<>();
-                    tagWrapper.in(TopicTagMap::getTagId, tagIdList);
-                    tagWrapper.groupBy(TopicTagMap::getTopicId);
+                    List<Long> topicIds;
                     if (Boolean.TRUE.equals(procedureTopic.getTagMatchAll())) {
-                        tagWrapper.having("COUNT(DISTINCT tag_id) >= " + tagIdList.size());
+                        topicIds = topicTagMapMapper.selectTopicIdsByAllTags(tagIdList, tagIdList.size());
+                    } else {
+                        topicIds = topicTagMapMapper.selectDistinctTopicIdsByAnyTags(tagIdList);
                     }
-                    List<TopicTagMap> topicTagMaps = topicTagMapMapper.selectList(tagWrapper);
 
-                    if (!topicTagMaps.isEmpty()) {
-                        List<Long> topicIds = topicTagMaps.stream()
-                                .map(TopicTagMap::getTopicId)
-                                .distinct()
-                                .collect(Collectors.toList());
+                    if (!topicIds.isEmpty()) {
+                        LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
+                        topicWrapper.in(Topic::getId, topicIds);
 
-                        if (!topicIds.isEmpty()) {
-                            LambdaQueryWrapper<Topic> topicWrapper = new LambdaQueryWrapper<>();
-                            topicWrapper.in(Topic::getId, topicIds);
-
-                            // 添加题目类型过滤
-                            if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
-                                String[] typeArray = procedureTopic.getTopicTypes().split(",");
-                                List<Integer> types = Arrays.stream(typeArray)
-                                        .filter(s -> s != null && !s.isEmpty())
-                                        .map(Integer::parseInt)
-                                        .collect(Collectors.toList());
-                                if (!types.isEmpty()) {
-                                    topicWrapper.in(Topic::getType, types);
-                                }
+                        // 添加题目类型过滤
+                        if (procedureTopic.getTopicTypes() != null && !procedureTopic.getTopicTypes().isEmpty()) {
+                            String[] typeArray = procedureTopic.getTopicTypes().split(",");
+                            List<Integer> types = Arrays.stream(typeArray)
+                                    .filter(s -> s != null && !s.isEmpty())
+                                    .map(Integer::parseInt)
+                                    .collect(Collectors.toList());
+                            if (!types.isEmpty()) {
+                                topicWrapper.in(Topic::getType, types);
                             }
-
-                            topicWrapper.orderByAsc(Topic::getNumber);
-                            return topicMapper.selectList(topicWrapper);
                         }
+
+                        topicWrapper.orderByAsc(Topic::getNumber);
+                        return topicMapper.selectList(topicWrapper);
                     }
                 }
             }

--- a/src/main/resources/sql/add_tag_match_all_to_procedure_topic.sql
+++ b/src/main/resources/sql/add_tag_match_all_to_procedure_topic.sql
@@ -1,0 +1,20 @@
+-- ============================================
+-- 课堂小测标签匹配模式字段迁移脚本
+-- 对应提交：a40a181487d71c04ae4629351d1fd1f38697fa47
+-- 说明：为 procedure_topic 表新增 tag_match_all 字段
+-- 含义：0-命中任一标签，1-必须命中全部标签
+-- ============================================
+
+-- 1. 新增字段，先允许为空，便于兼容已部署环境中的历史数据
+ALTER TABLE `procedure_topic`
+ADD COLUMN `tag_match_all` BIT(1) NULL COMMENT '标签匹配方式：0-命中任一标签，1-必须命中全部标签';
+
+-- 2. 回填历史数据
+-- 旧逻辑没有该字段，这里统一按“命中全部标签”初始化
+UPDATE `procedure_topic`
+SET `tag_match_all` = b'1'
+WHERE `tag_match_all` IS NULL;
+
+-- 3. 收紧字段约束，改为非空并设置默认值
+ALTER TABLE `procedure_topic`
+MODIFY COLUMN `tag_match_all` BIT(1) NOT NULL DEFAULT b'1' COMMENT '标签匹配方式：0-命中任一标签，1-必须命中全部标签';

--- a/src/test/java/com/example/demo/service/TeacherProcedureCreationServiceTest.java
+++ b/src/test/java/com/example/demo/service/TeacherProcedureCreationServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.BusinessException;
+import com.example.demo.mapper.DataCollectionMapper;
+import com.example.demo.mapper.ProcedureTopicMapMapper;
+import com.example.demo.mapper.ProcedureTopicMapper;
+import com.example.demo.mapper.TimedQuizProcedureMapper;
+import com.example.demo.mapper.TopicMapper;
+import com.example.demo.pojo.entity.ExperimentalProcedure;
+import com.example.demo.pojo.request.teacher.InsertTopicProcedureRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeacherProcedureCreationServiceTest {
+
+    @Mock
+    private ExperimentalProcedureService experimentalProcedureService;
+    @Mock
+    private DataCollectionMapper dataCollectionMapper;
+    @Mock
+    private ProcedureTopicMapper procedureTopicMapper;
+    @Mock
+    private ProcedureTopicMapMapper procedureTopicMapMapper;
+    @Mock
+    private TimedQuizProcedureMapper timedQuizProcedureMapper;
+    @Mock
+    private TopicMapper topicMapper;
+
+    @InjectMocks
+    private TeacherProcedureCreationService teacherProcedureCreationService;
+
+    @Test
+    void shouldAllowEmptyTagsWhenInsertTopicProcedureIsNotRandom() {
+        InsertTopicProcedureRequest request = buildBaseInsertRequest();
+        request.setIsRandom(false);
+        request.setTeacherSelectedTopicIds(List.of(101L));
+        request.setTopicTags(null);
+
+        when(experimentalProcedureService.getOne(any())).thenReturn(buildAfterProcedure());
+        when(topicMapper.selectCount(any())).thenReturn(1L);
+
+        assertDoesNotThrow(() -> teacherProcedureCreationService.insertTopicProcedure(request));
+    }
+
+    @Test
+    void shouldThrowBusinessExceptionWhenInsertTopicProcedureIsRandomAndTagsAreEmpty() {
+        InsertTopicProcedureRequest request = buildBaseInsertRequest();
+        request.setIsRandom(true);
+        request.setTopicNumber(5);
+        request.setTopicTags(null);
+
+        when(experimentalProcedureService.getOne(any())).thenReturn(buildAfterProcedure());
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> teacherProcedureCreationService.insertTopicProcedure(request));
+
+        assertEquals("随机抽题必须携带标签", ex.getMessage());
+    }
+
+    private InsertTopicProcedureRequest buildBaseInsertRequest() {
+        InsertTopicProcedureRequest request = new InsertTopicProcedureRequest();
+        request.setExperimentId(1L);
+        request.setAfterNumber(1);
+        request.setDurationMinutes(10);
+        request.setOffsetMinutes(0);
+        request.setRemark("test");
+        request.setProportion(10);
+        request.setIsSkip(false);
+        return request;
+    }
+
+    private ExperimentalProcedure buildAfterProcedure() {
+        ExperimentalProcedure procedure = new ExperimentalProcedure();
+        procedure.setId(10L);
+        procedure.setExperimentId(1L);
+        procedure.setNumber(1);
+        return procedure;
+    }
+}

--- a/src/test/java/com/example/demo/service/TopicTagMatchServiceTest.java
+++ b/src/test/java/com/example/demo/service/TopicTagMatchServiceTest.java
@@ -1,0 +1,131 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.BusinessException;
+import com.example.demo.mapper.TagMapper;
+import com.example.demo.mapper.TopicTagMapMapper;
+import com.example.demo.pojo.entity.Tag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicTagMatchServiceTest {
+
+    @Mock
+    private TagMapper tagMapper;
+
+    @Mock
+    private TopicTagMapMapper topicTagMapMapper;
+
+    @InjectMocks
+    private TopicTagMatchService topicTagMatchService;
+
+    private Tag subjectTag1;
+    private Tag subjectTag2;
+    private Tag difficultyTag;
+
+    @BeforeEach
+    void setUp() {
+        subjectTag1 = buildTag(1L, "1");
+        subjectTag2 = buildTag(2L, "1");
+        difficultyTag = buildTag(3L, "2");
+    }
+
+    @Test
+    void shouldMatchGroupedTagsByIntersectionAcrossTypesAndUnionWithinType() {
+        when(tagMapper.selectBatchIds(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of(subjectTag1, subjectTag2, difficultyTag));
+        when(topicTagMapMapper.selectDistinctTopicIdsByAnyTags(List.of(1L, 2L)))
+                .thenReturn(List.of(10L, 11L, 12L));
+        when(topicTagMapMapper.selectDistinctTopicIdsByAnyTags(List.of(3L)))
+                .thenReturn(List.of(11L, 12L, 13L));
+
+        List<Long> result = topicTagMatchService.selectTopicIdsByGroupedTags(List.of(1L, 2L, 3L));
+
+        assertEquals(List.of(11L, 12L), result);
+    }
+
+    @Test
+    void shouldDeduplicateTagIdsBeforeQuerying() {
+        when(tagMapper.selectBatchIds(List.of(1L, 3L)))
+                .thenReturn(List.of(subjectTag1, difficultyTag));
+        when(topicTagMapMapper.selectDistinctTopicIdsByAnyTags(List.of(1L)))
+                .thenReturn(List.of(100L, 101L));
+        when(topicTagMapMapper.selectDistinctTopicIdsByAnyTags(List.of(3L)))
+                .thenReturn(List.of(101L));
+
+        List<Long> result = topicTagMatchService.selectTopicIdsByGroupedTags(java.util.Arrays.asList(1L, 1L, 3L, null));
+
+        assertEquals(List.of(101L), result);
+        verify(tagMapper).selectBatchIds(List.of(1L, 3L));
+    }
+
+    @Test
+    void shouldQueryAllTagsWithDeduplicatedIds() {
+        when(tagMapper.selectBatchIds(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of(subjectTag1, subjectTag2, difficultyTag));
+        when(topicTagMapMapper.selectTopicIdsByAllTags(List.of(1L, 2L, 3L), 3))
+                .thenReturn(List.of(200L, 201L));
+
+        List<Long> result = topicTagMatchService.selectTopicIdsByAllTags(List.of(1L, 2L, 3L, 2L));
+
+        assertEquals(List.of(200L, 201L), result);
+    }
+
+    @Test
+    void shouldThrowWhenSomeTagsAreMissing() {
+        when(tagMapper.selectBatchIds(List.of(1L, 2L)))
+                .thenReturn(List.of(subjectTag1));
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> topicTagMatchService.selectTopicIdsByGroupedTags(List.of(1L, 2L)));
+
+        assertEquals("部分标签不存在，无法完成随机抽题", ex.getMessage());
+        verify(topicTagMapMapper, never()).selectDistinctTopicIdsByAnyTags(anyList());
+    }
+
+    @Test
+    void shouldThrowWhenTagTypeIsBlank() {
+        Tag invalidTag = buildTag(9L, "");
+        when(tagMapper.selectBatchIds(List.of(9L)))
+                .thenReturn(List.of(invalidTag));
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> topicTagMatchService.selectTopicIdsByGroupedTags(List.of(9L)));
+
+        assertEquals("标签类型缺失，无法完成随机抽题", ex.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenTagTypeIsUnknown() {
+        Tag invalidTag = buildTag(9L, "9");
+        when(tagMapper.selectBatchIds(List.of(9L)))
+                .thenReturn(List.of(invalidTag));
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> topicTagMatchService.selectTopicIdsByAllTags(List.of(9L)));
+
+        assertEquals("标签类型非法，无法完成随机抽题", ex.getMessage());
+        verify(topicTagMapMapper, never()).selectTopicIdsByAllTags(eq(List.of(9L)), eq(1));
+    }
+
+    private Tag buildTag(Long id, String type) {
+        Tag tag = new Tag();
+        tag.setId(id);
+        tag.setType(type);
+        return tag;
+    }
+}


### PR DESCRIPTION
## Summary
- 统一题库练习、课堂小测和限时答题的随机抽题标签匹配逻辑，支持四类标签按类型间与、类型内或筛题
- 兼容课堂小测 tagMatchAll 的历史语义，并补齐标签脏数据校验，避免静默放宽条件或直接 500
- 新增 TopicTagMatchService 相关单元测试，覆盖分组匹配、全标签匹配与异常场景

## Test plan
- [x] ./mvnw -q -DskipTests compile
- [x] ./mvnw -q -Dtest=TopicTagMatchServiceTest test

🤖 Generated with [Claude Code](https://claude.com/claude-code)