### PR TITLE
支持实验步骤答案延后显示

### DIFF
--- a/src/main/java/com/example/demo/pojo/entity/ExperimentalProcedure.java
+++ b/src/main/java/com/example/demo/pojo/entity/ExperimentalProcedure.java
@@ -74,4 +74,8 @@ public class ExperimentalProcedure {
     @Column(comment = "是否删除",type = "bit", notNull = true,defaultValue = "0")
     private Boolean isDeleted;
 
+    /** 答案是否在结束后才可见 */
+    @Column(comment = "答案是否在结束后才可见",type = "bit", notNull = true,defaultValue = "0")
+    private Boolean answerAfterEnd;
+
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
@@ -61,4 +61,9 @@ public class CreateDataCollectionProcedureRequest {
      * 步骤持续时间(分钟)
      */
     private Integer durationMinutes;
+
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateTimedQuizProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateTimedQuizProcedureRequest.java
@@ -38,6 +38,11 @@ public class CreateTimedQuizProcedureRequest {
     /** 老师选定的题目ID列表（仅在非随机模式时有效） */
     private List<Long> teacherSelectedTopicIds;
 
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
+
     // ===== 时间配置 =====
 
     /** 步骤开始时间偏移量(分钟),默认为0 */

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateTopicProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateTopicProcedureRequest.java
@@ -65,4 +65,9 @@ public class CreateTopicProcedureRequest {
      * 步骤持续时间(分钟)
      */
     private Integer durationMinutes;
+
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
@@ -64,4 +64,9 @@ public class InsertDataCollectionProcedureRequest {
      * 步骤持续时间(分钟)
      */
     private Integer durationMinutes;
+
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertTimedQuizProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertTimedQuizProcedureRequest.java
@@ -41,6 +41,11 @@ public class InsertTimedQuizProcedureRequest {
     /** 老师选定的题目ID列表（仅在非随机模式时有效） */
     private List<Long> teacherSelectedTopicIds;
 
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
+
     // ===== 时间配置 =====
 
     /** 步骤开始时间偏移量(分钟) */

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertTopicProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertTopicProcedureRequest.java
@@ -71,6 +71,11 @@ public class InsertTopicProcedureRequest {
      */
     private Integer durationMinutes;
 
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
+
 
     /**
      * 转为String

--- a/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
@@ -61,4 +61,9 @@ public class UpdateDataCollectionProcedureRequest {
      * 步骤持续时间(分钟)
      */
     private Integer durationMinutes;
+
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/UpdateTimedQuizProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/UpdateTimedQuizProcedureRequest.java
@@ -38,6 +38,11 @@ public class UpdateTimedQuizProcedureRequest {
     /** 老师选定的题目ID列表 */
     private List<Long> teacherSelectedTopicIds;
 
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
+
     // ===== 时间配置 =====
 
     /** 步骤开始时间偏移量(分钟) */

--- a/src/main/java/com/example/demo/pojo/request/teacher/UpdateTopicProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/UpdateTopicProcedureRequest.java
@@ -65,4 +65,9 @@ public class UpdateTopicProcedureRequest {
      * 步骤持续时间(分钟)
      */
     private Integer durationMinutes;
+
+    /**
+     * 答案是否在结束后才可见
+     */
+    private Boolean answerAfterEnd;
 }

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -43,6 +43,7 @@ public class ClassStudentProcedureQueryService {
     private final TopicMapper topicMapper;
     private final TopicTagMatchService topicTagMatchService;
     private final ProcedureTopicMapMapper procedureTopicMapMapper;
+    private final ClassExperimentClassRelationService classExperimentClassRelationService;
     private final ClassExperimentMapper classExperimentMapper;
     private final TimedQuizProcedureMapper timedQuizProcedureMapper;
     private final DownloadService downloadService;
@@ -158,8 +159,9 @@ public class ClassStudentProcedureQueryService {
         // 5. 批量获取学生姓名
         Map<String, String> studentNameMap = batchGetStudentNames(studentUsernames);
 
-        // 6. 计算是否已过答题时间
-        boolean isAfterEndTime = calculateIsAfterEndTime(request.getCourseId(), request.getExperimentId(), procedure);
+        // 6. 按班级实验计算是否已过答题时间，避免多班级实验或合班场景取错时间
+        boolean isAfterEndTime = calculateIsAfterEndTime(
+                request.getCourseId(), request.getClassCode(), request.getExperimentId(), procedure);
 
         // 7. 构建响应
         ClassStudentProcedureDetailResponse<T> response = new ClassStudentProcedureDetailResponse<>();
@@ -331,16 +333,27 @@ public class ClassStudentProcedureQueryService {
     }
 
     /**
-     * 计算是否已过答题时间
+     * 按班级实验计算是否已过答题时间
      */
-    private boolean calculateIsAfterEndTime(String courseId, Long experimentId, ExperimentalProcedure procedure) {
+    private boolean calculateIsAfterEndTime(String courseId, String classCode,
+                                            Long experimentId, ExperimentalProcedure procedure) {
         try {
-            LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
-            classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
-            classExperimentWrapper.eq(ClassExperiment::getExperimentId, experimentId);
-            ClassExperiment classExperiment = classExperimentMapper.selectOne(classExperimentWrapper);
+            List<Long> classExperimentIds = classExperimentClassRelationService.getExperimentIdsByClassCode(classCode);
+            if (classExperimentIds.isEmpty()) {
+                return false;
+            }
 
-            if (classExperiment != null && procedure.getOffsetMinutes() != null) {
+            LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
+            classExperimentWrapper.in(ClassExperiment::getId, classExperimentIds);
+            classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
+            classExperimentWrapper.eq(ClassExperiment::getExperimentId, String.valueOf(experimentId));
+            List<ClassExperiment> classExperiments = classExperimentMapper.selectList(classExperimentWrapper);
+
+            if (classExperiments.isEmpty() || procedure.getOffsetMinutes() == null) {
+                return false;
+            }
+
+            for (ClassExperiment classExperiment : classExperiments) {
                 LocalDateTime endTime = ProcedureTimeCalculator.calculateEndTime(
                         ProcedureTimeCalculator.calculateStartTime(
                                 classExperiment.getStartTime(),
@@ -349,12 +362,13 @@ public class ClassStudentProcedureQueryService {
                         procedure.getDurationMinutes()
                 );
 
-                if (endTime != null) {
-                    return LocalDateTime.now().isAfter(endTime);
+                if (endTime != null && LocalDateTime.now().isAfter(endTime)) {
+                    return true;
                 }
             }
         } catch (Exception e) {
-            log.error("计算步骤时间失败", e);
+            log.error("按班级实验计算步骤时间失败，classCode: {}, courseId: {}, experimentId: {}",
+                    classCode, courseId, experimentId, e);
         }
         return false;
     }

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -159,21 +159,23 @@ public class ClassStudentProcedureQueryService {
         // 5. 批量获取学生姓名
         Map<String, String> studentNameMap = batchGetStudentNames(studentUsernames);
 
-        // 6. 按班级实验计算是否已过答题时间，避免多班级实验或合班场景取错时间
-        boolean isAfterEndTime = calculateIsAfterEndTime(
-                request.getCourseId(), request.getClassCode(), request.getExperimentId(), procedure);
-
-        // 7. 构建响应
+        // 6. 构建响应
         ClassStudentProcedureDetailResponse<T> response = new ClassStudentProcedureDetailResponse<>();
         response.setProcedureId(procedure.getId());
         response.setProcedureNumber(procedure.getNumber());
         response.setProcedureType(procedure.getType());
         response.setProcedureRemark(procedure.getRemark());
         response.setProportion(procedure.getProportion());
-        response.setIsAfterEndTime(isAfterEndTime);
 
+        boolean hasAnySubmissionAfterEndTime = false;
         List<ClassStudentProcedureDetailResponse.StudentProcedureItem<T>> items = new ArrayList<>();
         for (StudentExperimentalProcedure submission : submissions) {
+            boolean submissionIsAfterEndTime = calculateIsAfterEndTime(
+                    request.getCourseId(), request.getClassCode(), request.getExperimentId(), procedure, submission);
+            if (submissionIsAfterEndTime) {
+                hasAnySubmissionAfterEndTime = true;
+            }
+
             ClassStudentProcedureDetailResponse.StudentProcedureItem<T> item =
                 new ClassStudentProcedureDetailResponse.StudentProcedureItem<>();
             item.setStudentUsername(submission.getStudentUsername());
@@ -183,12 +185,14 @@ public class ClassStudentProcedureQueryService {
             item.setTeacherComment(submission.getTeacherComment());
             item.setIsGraded(submission.getIsGraded());
 
-            // 根据类型填充详情
-            T detail = (T) fillCompletedDetail(procedure, submission, submission.getStudentUsername(), isAfterEndTime, procedureType);
+            // 根据当前提交所属课次填充详情
+            T detail = (T) fillCompletedDetail(
+                    procedure, submission, submission.getStudentUsername(), submissionIsAfterEndTime, procedureType);
             item.setDetail(detail);
 
             items.add(item);
         }
+        response.setIsAfterEndTime(hasAnySubmissionAfterEndTime);
         response.setStudents(items);
 
         return response;
@@ -333,42 +337,58 @@ public class ClassStudentProcedureQueryService {
     }
 
     /**
-     * 按班级实验计算是否已过答题时间
+     * 按当前提交所属课次计算是否已过答题时间
      */
     private boolean calculateIsAfterEndTime(String courseId, String classCode,
-                                            Long experimentId, ExperimentalProcedure procedure) {
+                                            Long experimentId, ExperimentalProcedure procedure,
+                                            StudentExperimentalProcedure submission) {
         try {
-            List<Long> classExperimentIds = classExperimentClassRelationService.getExperimentIdsByClassCode(classCode);
-            if (classExperimentIds.isEmpty()) {
-                return false;
-            }
+            ClassExperiment classExperiment = null;
 
-            LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
-            classExperimentWrapper.in(ClassExperiment::getId, classExperimentIds);
-            classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
-            classExperimentWrapper.eq(ClassExperiment::getExperimentId, String.valueOf(experimentId));
-            List<ClassExperiment> classExperiments = classExperimentMapper.selectList(classExperimentWrapper);
-
-            if (classExperiments.isEmpty() || procedure.getOffsetMinutes() == null) {
-                return false;
-            }
-
-            for (ClassExperiment classExperiment : classExperiments) {
-                LocalDateTime endTime = ProcedureTimeCalculator.calculateEndTime(
-                        ProcedureTimeCalculator.calculateStartTime(
-                                classExperiment.getStartTime(),
-                                procedure.getOffsetMinutes()
-                        ),
-                        procedure.getDurationMinutes()
-                );
-
-                if (endTime != null && LocalDateTime.now().isAfter(endTime)) {
-                    return true;
+            // 优先按提交记录落库的班级实验ID精确计算，避免多课次场景串判
+            if (submission.getClassExperimentId() != null) {
+                classExperiment = classExperimentMapper.selectById(submission.getClassExperimentId());
+                if (classExperiment != null
+                        && (!Objects.equals(classExperiment.getCourseId(), courseId)
+                        || !Objects.equals(classExperiment.getExperimentId(), String.valueOf(experimentId)))) {
+                    log.warn("提交记录的班级实验与当前查询条件不匹配，submissionId: {}, classExperimentId: {}",
+                            submission.getId(), submission.getClassExperimentId());
+                    classExperiment = null;
                 }
             }
+
+            // 历史兼容：仅在缺少 classExperimentId 时，回退到班级维度查找最近课次
+            if (classExperiment == null) {
+                List<Long> classExperimentIds = classExperimentClassRelationService.getExperimentIdsByClassCode(classCode);
+                if (classExperimentIds.isEmpty()) {
+                    return false;
+                }
+
+                LambdaQueryWrapper<ClassExperiment> classExperimentWrapper = new LambdaQueryWrapper<>();
+                classExperimentWrapper.in(ClassExperiment::getId, classExperimentIds);
+                classExperimentWrapper.eq(ClassExperiment::getCourseId, courseId);
+                classExperimentWrapper.eq(ClassExperiment::getExperimentId, String.valueOf(experimentId));
+                classExperimentWrapper.orderByDesc(ClassExperiment::getStartTime);
+                classExperimentWrapper.last("LIMIT 1");
+                classExperiment = classExperimentMapper.selectOne(classExperimentWrapper, false);
+            }
+
+            if (classExperiment == null || procedure.getOffsetMinutes() == null) {
+                return false;
+            }
+
+            LocalDateTime endTime = ProcedureTimeCalculator.calculateEndTime(
+                    ProcedureTimeCalculator.calculateStartTime(
+                            classExperiment.getStartTime(),
+                            procedure.getOffsetMinutes()
+                    ),
+                    procedure.getDurationMinutes()
+            );
+
+            return endTime != null && LocalDateTime.now().isAfter(endTime);
         } catch (Exception e) {
-            log.error("按班级实验计算步骤时间失败，classCode: {}, courseId: {}, experimentId: {}",
-                    classCode, courseId, experimentId, e);
+            log.error("按提交课次计算步骤时间失败，submissionId: {}, classExperimentId: {}, classCode: {}, courseId: {}, experimentId: {}",
+                    submission.getId(), submission.getClassExperimentId(), classCode, courseId, experimentId, e);
         }
         return false;
     }

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -320,6 +320,17 @@ public class ClassStudentProcedureQueryService {
     }
 
     /**
+     * 判断已提交步骤是否允许返回答案信息
+     *
+     * @param procedure 步骤信息
+     * @param isAfterEndTime 当前是否已过步骤结束时间
+     * @return true-允许返回答案，false-不允许返回答案
+     */
+    private boolean canShowAnswerAfterSubmission(ExperimentalProcedure procedure, boolean isAfterEndTime) {
+        return !Boolean.TRUE.equals(procedure.getAnswerAfterEnd()) || isAfterEndTime;
+    }
+
+    /**
      * 计算是否已过答题时间
      */
     private boolean calculateIsAfterEndTime(String courseId, Long experimentId, ExperimentalProcedure procedure) {
@@ -482,8 +493,9 @@ public class ClassStudentProcedureQueryService {
                         detail.setTableCellAnswers(TableCellAnswer.fromMap(tableCellAnswers));
                     }
 
-                    // 如果已过答题时间，返回正确答案
-                    if (isAfterEndTime && dataCollection.getCorrectAnswer() != null) {
+                    // 根据答案展示时机配置决定是否返回正确答案
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)
+                            && dataCollection.getCorrectAnswer() != null) {
                         detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
                     }
                 }
@@ -556,11 +568,13 @@ public class ClassStudentProcedureQueryService {
                     String studentAnswer = studentAnswers.get(topic.getId());
                     item.setStudentAnswer(TopicAnswerContractUtil.normalizeForApi(topic.getType(), studentAnswer));
 
-                    // 返回正确答案和是否正确
-                    item.setCorrectAnswer(
-                        TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
-                    item.setIsCorrect(
-                        TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    // 根据答案展示时机配置决定是否返回正确答案和判题结果
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)) {
+                        item.setCorrectAnswer(
+                            TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
+                        item.setIsCorrect(
+                            TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    }
 
                     topicItems.add(item);
                 }
@@ -648,11 +662,13 @@ public class ClassStudentProcedureQueryService {
                     String studentAnswer = studentAnswers.get(topic.getId());
                     item.setStudentAnswer(TopicAnswerContractUtil.normalizeForApi(topic.getType(), studentAnswer));
 
-                    // 返回正确答案和是否正确
-                    item.setCorrectAnswer(
-                        TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
-                    item.setIsCorrect(
-                        TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    // 根据答案展示时机配置决定是否返回正确答案和判题结果
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)) {
+                        item.setCorrectAnswer(
+                            TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
+                        item.setIsCorrect(
+                            TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    }
 
                     topicItems.add(item);
                 }

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -372,10 +372,11 @@ public class StudentProcedureQueryService {
                         detail.setTableCellAnswers(TableCellAnswer.fromMap(tableCellAnswers));
                     }
 
-                    // 如果已过答题时间，返回正确答案
-//                    if (isAfterEndTime && dataCollection.getCorrectAnswer() != null) {
+                    // 根据答案展示时机配置决定是否返回正确答案
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)
+                            && dataCollection.getCorrectAnswer() != null) {
                         detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
-//                    }
+                    }
                 }
 
                 response.setDataCollectionDetail(detail);
@@ -451,11 +452,13 @@ public class StudentProcedureQueryService {
                     String studentAnswer = studentAnswers.get(topic.getId());
                     item.setStudentAnswer(TopicAnswerContractUtil.normalizeForApi(topic.getType(), studentAnswer));
 
-                    // 返回正确答案和是否正确
-                    item.setCorrectAnswer(
-                        TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
-                    item.setIsCorrect(
-                        TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    // 根据答案展示时机配置决定是否返回正确答案和判题结果
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)) {
+                        item.setCorrectAnswer(
+                            TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
+                        item.setIsCorrect(
+                            TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    }
 
 
                     item.setNumber(topic.getNumber());
@@ -571,6 +574,17 @@ public class StudentProcedureQueryService {
     }
 
     /**
+     * 判断已提交步骤是否允许返回答案信息
+     *
+     * @param procedure 步骤信息
+     * @param isAfterEndTime 当前是否已过步骤结束时间
+     * @return true-允许返回答案，false-不允许返回答案
+     */
+    private boolean canShowAnswerAfterSubmission(ExperimentalProcedure procedure, boolean isAfterEndTime) {
+        return !Boolean.TRUE.equals(procedure.getAnswerAfterEnd()) || isAfterEndTime;
+    }
+
+    /**
      * 解析题库答案
      * 答案格式：{"type": "TOPIC", "data": {"题目ID": "答案"}}
      *
@@ -642,11 +656,13 @@ public class StudentProcedureQueryService {
                     String studentAnswer = studentAnswers.get(topic.getId());
                     item.setStudentAnswer(TopicAnswerContractUtil.normalizeForApi(topic.getType(), studentAnswer));
 
-                    // 返回正确答案和是否正确
-                    item.setCorrectAnswer(
-                        TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
-                    item.setIsCorrect(
-                        TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    // 根据答案展示时机配置决定是否返回正确答案和判题结果
+                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)) {
+                        item.setCorrectAnswer(
+                            TopicAnswerContractUtil.normalizeForApi(topic.getType(), topic.getCorrectAnswer()));
+                        item.setIsCorrect(
+                            TopicAnswerContractUtil.answersEqual(topic.getType(), studentAnswer, topic.getCorrectAnswer()));
+                    }
 
 
                     topicItems.add(item);

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -165,6 +165,7 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -258,6 +259,7 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -405,6 +407,10 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : procedure.getIsSkip());
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : procedure.getProportion());
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：仅在前端传值时覆盖原有设置
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null
+                ? request.getAnswerAfterEnd()
+                : procedure.getAnswerAfterEnd());
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -493,6 +499,10 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : procedure.getIsSkip());
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : procedure.getProportion());
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：仅在前端传值时覆盖原有设置
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null
+                ? request.getAnswerAfterEnd()
+                : procedure.getAnswerAfterEnd());
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -674,6 +684,8 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：未传时默认允许立即查看答案
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -782,6 +794,8 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：未传时默认允许立即查看答案
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时��字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -966,6 +980,8 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：未传时默认允许立即查看答案
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());
@@ -1059,6 +1075,10 @@ public class TeacherProcedureCreationService {
         }
         if (request.getRemark() != null) {
             procedure.setRemark(request.getRemark());
+        }
+        // 答案展示时机配置：仅在前端传值时覆盖原有设置
+        if (request.getAnswerAfterEnd() != null) {
+            procedure.setAnswerAfterEnd(request.getAnswerAfterEnd());
         }
 
         // 设置时间字段
@@ -1178,6 +1198,8 @@ public class TeacherProcedureCreationService {
         procedure.setIsSkip(request.getIsSkip() != null ? request.getIsSkip() : false);
         procedure.setProportion(request.getProportion() != null ? request.getProportion() : 0);
         procedure.setRemark(request.getRemark());
+        // 答案展示时机配置：未传时默认允许立即查看答案
+        procedure.setAnswerAfterEnd(request.getAnswerAfterEnd() != null ? request.getAnswerAfterEnd() : false);
 
         // 设置时间字段
         validateAndSetTimeFields(procedure, request.getOffsetMinutes(), request.getDurationMinutes());


### PR DESCRIPTION
## Summary
- 为实验步骤新增 `answerAfterEnd` 配置，并补齐教师端创建、插入、更新链路的写回逻辑
- 在学生端与班级教师端已提交详情查询中接入答案延后显示判定，按步骤配置和结束时间控制 `correctAnswer` 与 `isCorrect` 返回
- 修复班级维度时间判定逻辑，避免多班级实验或合班场景误用其他班级实验时间导致答案提前显示或错误隐藏

## Test plan
- [ ] 创建数据收集、题库练习、限时答题步骤时分别验证 `answerAfterEnd=true/false/不传` 的落库结果
- [ ] 更新与插入上述三类步骤时验证 `answerAfterEnd` 的保存与默认值策略
- [ ] 学生端已提交详情接口验证 `answerAfterEnd=true` 时未结束不返回答案、结束后返回答案
- [ ] 班级教师端已提交详情接口验证多班级实验或合班场景下按当前班级实验时间判断答案可见性

🤖 Generated with [Claude Code](https://claude.com/claude-code)