### PR TITLE
重构数据收集正确答案为 min/max 范围

### DIFF
--- a/src/main/java/com/example/demo/pojo/dto/mapvo/AnswerRange.java
+++ b/src/main/java/com/example/demo/pojo/dto/mapvo/AnswerRange.java
@@ -1,0 +1,28 @@
+package com.example.demo.pojo.dto.mapvo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 接口返回的正确答案范围。
+ */
+@Data
+@AllArgsConstructor
+public class AnswerRange {
+
+    /** 最小值（包含边界） */
+    private String min;
+
+    /** 最大值（包含边界） */
+    private String max;
+
+    public static AnswerRange fromStoredValue(String storedValue) {
+        DataField field = new DataField();
+        field.applyCorrectAnswerValue(storedValue);
+        return new AnswerRange(field.getMin(), field.getMax());
+    }
+
+    public static AnswerRange fromExactValue(String storedValue) {
+        return new AnswerRange(storedValue, storedValue);
+    }
+}

--- a/src/main/java/com/example/demo/pojo/dto/mapvo/DataField.java
+++ b/src/main/java/com/example/demo/pojo/dto/mapvo/DataField.java
@@ -1,8 +1,13 @@
 package com.example.demo.pojo.dto.mapvo;
 
 import com.example.demo.exception.BusinessException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,10 +16,14 @@ import java.util.stream.Collectors;
 /**
  * 数据收集字段
  * 用于替代 Map<String, String> 结构（数据收集字段）
- * Key: 字段名，Value: 字段值
+ * Key: 字段名，Value: 最小值和最大值确定的答案范围
  */
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DataField {
+
+    private static final String RANGE_PREFIX = "RANGE|";
 
     /**
      * 字段名
@@ -22,15 +31,14 @@ public class DataField {
     private String fieldName;
 
     /**
-     * 字段值
+     * 范围答案最小值（包含边界）。
      */
-    private String value;
+    private String min;
 
     /**
-     * 字段级误差百分比（可选，覆盖步骤级误差，单位：%）
-     * 示例：5 表示允许±5%的相对误差
+     * 范围答案最大值（包含边界）。
      */
-    private Double tolerance;
+    private String max;
 
     /**
      * 将 List<DataField> 转换为 Map<String, String>
@@ -44,25 +52,10 @@ public class DataField {
         }
         try {
             return fields.stream()
-                    .collect(Collectors.toMap(DataField::getFieldName, DataField::getValue));
+                    .collect(Collectors.toMap(DataField::getFieldName, DataField::toCorrectAnswerValue));
         } catch (IllegalStateException e) {
             throw new BusinessException(400,"一个步骤不能有相同名字的数据");
         }
-    }
-
-    /**
-     * 将 List<DataField> 转换为 Map<String, Double>（字段级误差映射）
-     *
-     * @param fields 字段列表
-     * @return Map<字段名, 误差百分比>
-     */
-    public static Map<String, Double> toToleranceMap(List<DataField> fields) {
-        if (fields == null || fields.isEmpty()) {
-            return Map.of();
-        }
-        return fields.stream()
-                .filter(field -> field.getTolerance() != null)
-                .collect(Collectors.toMap(DataField::getFieldName, DataField::getTolerance));
     }
 
     /**
@@ -72,17 +65,6 @@ public class DataField {
      * @return 字段列表
      */
     public static List<DataField> fromMap(Map<String, String> map) {
-        return fromMap(map, null);
-    }
-
-    /**
-     * 将 Map<String, String> 和误差映射转换为 List<DataField>
-     *
-     * @param map Map<字段名, 字段值>
-     * @param toleranceMap Map<字段名, 误差百分比>
-     * @return 字段列表
-     */
-    public static List<DataField> fromMap(Map<String, String> map, Map<String, Double> toleranceMap) {
         if (map == null || map.isEmpty()) {
             return new ArrayList<>();
         }
@@ -90,12 +72,134 @@ public class DataField {
                 .map(entry -> {
                     DataField field = new DataField();
                     field.setFieldName(entry.getKey());
-                    field.setValue(entry.getValue());
-                    if (toleranceMap != null) {
-                        field.setTolerance(toleranceMap.get(entry.getKey()));
-                    }
+                    field.applyCorrectAnswerValue(entry.getValue());
                     return field;
                 })
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 将字段答案转换为 correct_answer Map 中保存的字符串值。
+     */
+    public String toCorrectAnswerValue() {
+        boolean hasMin = min != null && !min.trim().isEmpty();
+        boolean hasMax = max != null && !max.trim().isEmpty();
+        if (!hasMin || !hasMax) {
+            throw new BusinessException(400, "最小值和最大值必须同时填写");
+        }
+
+        BigDecimal minNumber = parseRangeBoundary(min, "最小值");
+        BigDecimal maxNumber = parseRangeBoundary(max, "最大值");
+        if (minNumber.compareTo(maxNumber) > 0) {
+            throw new BusinessException(400, "最小值不能大于最大值");
+        }
+        return RANGE_PREFIX + min.trim() + "|" + max.trim();
+    }
+
+    /**
+     * 将 correct_answer 中的字符串值展开到旧值或范围字段。
+     */
+    public void applyCorrectAnswerValue(String correctAnswerValue) {
+        min = null;
+        max = null;
+
+        if (correctAnswerValue == null) {
+            return;
+        }
+        if (!correctAnswerValue.startsWith(RANGE_PREFIX)) {
+            min = correctAnswerValue;
+            max = correctAnswerValue;
+            return;
+        }
+
+        String[] parts = correctAnswerValue.split("\\|", -1);
+        if (parts.length != 3 || parts[1].trim().isEmpty() || parts[2].trim().isEmpty()) {
+            throw new IllegalArgumentException("非法的正确答案范围格式");
+        }
+
+        String storedMin = parts[1].trim();
+        String storedMax = parts[2].trim();
+        BigDecimal minNumber;
+        BigDecimal maxNumber;
+        try {
+            minNumber = new BigDecimal(storedMin);
+            maxNumber = new BigDecimal(storedMax);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("正确答案范围边界必须是有效数字", e);
+        }
+        if (minNumber.compareTo(maxNumber) > 0) {
+            throw new IllegalArgumentException("正确答案范围最小值不能大于最大值");
+        }
+
+        min = storedMin;
+        max = storedMax;
+    }
+
+    /**
+     * 兼容旧 remark 中的 value 字段，反序列化时直接转换为等值范围。
+     */
+    @JsonSetter("value")
+    @JsonProperty(value = "value", access = JsonProperty.Access.WRITE_ONLY)
+    public void applyLegacyValue(String legacyValue) {
+        if (legacyValue != null && min == null && max == null) {
+            min = legacyValue;
+            max = legacyValue;
+        }
+    }
+
+    /**
+     * 判断 correct_answer 中的字段值是否为范围格式。
+     */
+    public static boolean isRangeCorrectAnswer(String correctAnswerValue) {
+        return correctAnswerValue != null && correctAnswerValue.startsWith(RANGE_PREFIX);
+    }
+
+    /**
+     * 使用包含边界的最小值/最大值判断学生答案是否在正确范围内。
+     */
+    public static boolean isAnswerWithinRange(String studentAnswer, String correctAnswerValue) {
+        if (studentAnswer == null || !isRangeCorrectAnswer(correctAnswerValue)) {
+            return false;
+        }
+        String[] parts = correctAnswerValue.split("\\|", -1);
+        if (parts.length != 3) {
+            return false;
+        }
+        try {
+            BigDecimal student = new BigDecimal(studentAnswer.trim());
+            BigDecimal min = new BigDecimal(parts[1].trim());
+            BigDecimal max = new BigDecimal(parts[2].trim());
+            return min.compareTo(max) <= 0
+                    && student.compareTo(min) >= 0
+                    && student.compareTo(max) <= 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 按填空答案契约比较学生答案：新数据使用范围，旧精确值按等值范围处理。
+     */
+    public static boolean isFillBlankAnswerCorrect(String studentAnswer, String correctAnswerValue) {
+        if (studentAnswer == null || correctAnswerValue == null) {
+            return false;
+        }
+        if (isRangeCorrectAnswer(correctAnswerValue)) {
+            return isAnswerWithinRange(studentAnswer, correctAnswerValue);
+        }
+        try {
+            return new BigDecimal(studentAnswer.trim())
+                    .compareTo(new BigDecimal(correctAnswerValue.trim())) == 0;
+        } catch (NumberFormatException e) {
+            return studentAnswer.trim().equalsIgnoreCase(correctAnswerValue.trim());
+        }
+    }
+
+    private static BigDecimal parseRangeBoundary(String boundary, String fieldLabel) {
+        try {
+            return new BigDecimal(boundary.trim());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(400, fieldLabel + "必须是有效数字");
+        }
     }
 }

--- a/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
+++ b/src/main/java/com/example/demo/pojo/dto/remark/FillBlankRemarkDTO.java
@@ -14,8 +14,11 @@ import java.util.List;
  * 填空类型 remark DTO
  * 用于序列化/反序列化 data_collection.remark 中的填空类型 JSON
  *
- * JSON 格式：
- * {"fillBlanks":[{"fieldName":"Uab","value":"","tolerance":5.0}]}
+ * 范围答案 JSON 格式：
+ * {"fillBlanks":[{"fieldName":"Uab","min":"210","max":"230"}]}
+ *
+ * 旧的精确答案在生成 DTO 时转换为 min 与 max 相同的范围：
+ * {"fillBlanks":[{"fieldName":"Uab","min":"220","max":"220"}]}
  */
 @Data
 @Builder
@@ -25,6 +28,6 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FillBlankRemarkDTO {
 
-    /** 填空数据列表（字段名 + 值 + 误差） */
+    /** 填空数据列表（字段名 + 最小值 + 最大值） */
     private List<DataField> fillBlanks;
 }

--- a/src/main/java/com/example/demo/pojo/entity/DataCollection.java
+++ b/src/main/java/com/example/demo/pojo/entity/DataCollection.java
@@ -8,9 +8,17 @@ import com.tangzc.autotable.annotation.TableIndex;
 import com.tangzc.autotable.annotation.enums.IndexTypeEnum;
 import com.tangzc.mpe.autotable.annotation.Column;
 import com.tangzc.mpe.autotable.annotation.Table;
+import com.example.demo.pojo.dto.mapvo.AnswerRange;
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.util.DataCollectionDataUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * 实验步骤-数据收集表
@@ -22,6 +30,8 @@ import java.time.LocalDateTime;
 @TableName("data_collection")
 @TableIndex(name = "uk_procedure_data", fields = {"experimentalProcedureId"}, type = IndexTypeEnum.UNIQUE)
 public class DataCollection {
+
+    private static final ObjectMapper CORRECT_ANSWER_MAPPER = new ObjectMapper();
 
     /** 主键ID */
     @TableId(type = IdType.AUTO)
@@ -48,11 +58,12 @@ public class DataCollection {
     private Boolean needDoc;
 
     /** 正确答案（JSON格式，用于自动判分） */
+    @JsonIgnore
     @Column(comment = "正确答案（JSON格式，用于自动判分）", type = "text")
     private String correctAnswer;
 
-    /** 误差范围（可选，用于数值类答案的判分） */
-    @Column(comment = "误差范围（可选，用于数值类答案的判分）", type = "double")
+    /** 表格类型步骤级误差范围（填空范围答案不使用） */
+    @Column(comment = "表格类型步骤级误差范围（填空范围答案不使用）", type = "double")
     private Double tolerance;
 
     /** 创建时间 */
@@ -62,4 +73,58 @@ public class DataCollection {
     /** 是否删除：0-否，1-是 */
     @Column(comment = "是否删除：0-否，1-是", type = "bit", defaultValue = "0")
     private Boolean isDeleted;
+
+    /**
+     * 判分路径：将正确答案 JSON 严格解析为 Map。
+     * JSON 非法时抛出异常，由判分流程统一处理。
+     */
+    public Map<String, String> parseCorrectAnswerMap() {
+        if (correctAnswer == null || correctAnswer.trim().isEmpty()) {
+            return Map.of();
+        }
+        try {
+            Map<String, String> parsedAnswers = CORRECT_ANSWER_MAPPER.readValue(
+                    correctAnswer,
+                    new TypeReference<Map<String, String>>() {}
+            );
+            if (!Long.valueOf(2L).equals(type)) {
+                parsedAnswers.values().stream()
+                        .filter(com.example.demo.pojo.dto.mapvo.DataField::isRangeCorrectAnswer)
+                        .forEach(AnswerRange::fromStoredValue);
+            }
+            return parsedAnswers;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("解析数据收集正确答案失败", e);
+        }
+    }
+
+    /**
+     * 填空回显路径：解析 remark 结构，并按答案展示策略决定是否合并正确答案。
+     * 旧 remark 中的 value 仅在服务端解析；不允许展示答案时会清除其转换结果。
+     */
+    public FillBlankRemarkDTO resolveFillBlankRemark(boolean includeCorrectAnswer) {
+        Map<String, String> storedAnswers = includeCorrectAnswer
+                ? parseCorrectAnswerMap()
+                : Map.of();
+        return DataCollectionDataUtil.parseFillBlankRemark(
+                remark, storedAnswers, includeCorrectAnswer);
+    }
+
+    /**
+     * 响应路径：将数据库编码转换为直接包含 min/max 的范围 Map。
+     */
+    public Map<String, AnswerRange> resolveCorrectAnswerRanges() {
+        Map<String, String> storedAnswers = parseCorrectAnswerMap();
+        if (storedAnswers.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, AnswerRange> ranges = new LinkedHashMap<>();
+        boolean fillBlankType = !Long.valueOf(2L).equals(type);
+        storedAnswers.forEach((key, value) -> ranges.put(
+                key,
+                fillBlankType
+                        ? AnswerRange.fromStoredValue(value)
+                        : AnswerRange.fromExactValue(value)));
+        return ranges;
+    }
 }

--- a/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/CreateDataCollectionProcedureRequest.java
@@ -28,7 +28,7 @@ public class CreateDataCollectionProcedureRequest {
     /** 数据类型：1-填空类型（关键数据），2-表格类型，3-文件数据类型 */
     private Integer dataType;
 
-    /** 收集数据字段列表，当dataType=1时使用，只对数字类型数据进行自动判分。每个字段可单独配置tolerance属性（百分比，单位：%），优先级高于步骤级tolerance */
+    /** 收集数据字段列表，当dataType=1时使用，每个字段通过min和max定义正确范围 */
     private List<DataField> dataFields;
 
     /** 表格行表头（第一列的标识），类型：List<String>，示例：["实验1", "实验2", "实验3"]，当dataType=2时使用 */
@@ -43,7 +43,7 @@ public class CreateDataCollectionProcedureRequest {
     /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
     private List<ColumnTolerance> tableColumnTolerances;
 
-    /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
+    /** 表格类型步骤级误差百分比（可选，dataType=2时使用） */
     private Double tolerance;
 
     /** 是否需要提交照片 */

--- a/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/InsertDataCollectionProcedureRequest.java
@@ -31,7 +31,7 @@ public class InsertDataCollectionProcedureRequest {
     /** 数据类型：1-填空类型（关键数据），2-表格类型 */
     private Integer dataType;
 
-    /** 收集数据字段列表，当dataType=1时使用，只对数字类型数据进行自动判分。每个字段可单独配置tolerance属性（百分比，单位：%），优先级高于步骤级tolerance */
+    /** 收集数据字段列表，当dataType=1时使用，每个字段通过min和max定义正确范围 */
     private List<DataField> dataFields;
 
     /** 表格行表头（第一列的标识），类型：List<String>，示例：["实验1", "实验2", "实验3"]，当dataType=2时使用 */
@@ -46,7 +46,7 @@ public class InsertDataCollectionProcedureRequest {
     /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
     private List<ColumnTolerance> tableColumnTolerances;
 
-    /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
+    /** 表格类型步骤级误差百分比（可选，dataType=2时使用） */
     private Double tolerance;
 
     /** 是否需要提交照片 */

--- a/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
+++ b/src/main/java/com/example/demo/pojo/request/teacher/UpdateDataCollectionProcedureRequest.java
@@ -28,7 +28,7 @@ public class UpdateDataCollectionProcedureRequest {
     /** 数据类型：1-填空类型（关键数据），2-表格类型 */
     private Integer dataType;
 
-    /** 收集数据字段列表，当dataType=1时使用，只对数字类型数据进行自动判分。每个字段可单独配置tolerance属性（百分比，单位：%），优先级高于步骤级tolerance */
+    /** 收集数据字段列表，当dataType=1时使用，每个字段通过min和max定义正确范围 */
     private List<DataField> dataFields;
 
     /** 表格行表头（第一列的标识），类型：List<String>，示例：["实验1", "实验2", "实验3"]，当dataType=2时使用 */
@@ -43,7 +43,7 @@ public class UpdateDataCollectionProcedureRequest {
     /** 表格列级误差列表（可选），同一列所有单元格共享该误差配置，优先级低于单元格级误差，高于步骤级误差 */
     private List<ColumnTolerance> tableColumnTolerances;
 
-    /** 步骤级误差百分比（可选，用于数值类答案的判分），类型：Double，用途：数值类答案的允许相对误差，示例：5 (表示±5%的误差)，可以为null，表示精确匹配 */
+    /** 表格类型步骤级误差百分比（可选，dataType=2时使用） */
     private Double tolerance;
 
     /** 是否需要提交照片 */

--- a/src/main/java/com/example/demo/pojo/response/BaseSubmittedDataCollectionDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/BaseSubmittedDataCollectionDetailResponse.java
@@ -1,11 +1,14 @@
 package com.example.demo.pojo.response;
 
 import com.example.demo.pojo.dto.mapvo.FillBlankAnswer;
+import com.example.demo.pojo.dto.mapvo.AnswerRange;
 import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 带作答结果的数据收集详情基础响应
@@ -36,11 +39,10 @@ public class BaseSubmittedDataCollectionDetailResponse extends BaseDataCollectio
     /**
      * 正确答案
      */
-    private String correctAnswer;
+    private Map<String, AnswerRange> correctAnswer;
 
-    /**
-     * 误差范围（用于数值类答案的判分）
-     */
+    /** 表格类型步骤级误差，填空类型不返回 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double tolerance;
 
     /**

--- a/src/main/java/com/example/demo/pojo/response/TeacherDataCollectionProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/TeacherDataCollectionProcedureDetailResponse.java
@@ -2,6 +2,7 @@ package com.example.demo.pojo.response;
 
 import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
 import com.example.demo.pojo.dto.remark.TableRemarkDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -88,8 +89,7 @@ public class TeacherDataCollectionProcedureDetailResponse {
      */
     private Boolean dataNeedDoc;
 
-    /**
-     * 步骤级误差百分比（可选，用于数值类答案的判分），单位：%
-     */
+    /** 表格类型步骤级误差百分比，填空类型不返回 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double tolerance;
 }

--- a/src/main/java/com/example/demo/pojo/response/TeacherProcedureDetailResponse.java
+++ b/src/main/java/com/example/demo/pojo/response/TeacherProcedureDetailResponse.java
@@ -2,6 +2,7 @@ package com.example.demo.pojo.response;
 
 import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
 import com.example.demo.pojo.dto.remark.TableRemarkDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -117,9 +118,8 @@ public class TeacherProcedureDetailResponse {
      */
     private Boolean dataNeedDoc;
 
-    /**
-     * 步骤级误差百分比（可选，用于数值类答案的判分），单位：%（类型2时有效）
-     */
+    /** 表格类型步骤级误差百分比，填空类型不返回 */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double tolerance;
 
     // ===== 类型3：题库答题详细信息 =====

--- a/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/ClassStudentProcedureQueryService.java
@@ -466,10 +466,12 @@ public class ClassStudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                fillDataCollectionRemark(detail, dataCollection);
+                boolean canShowCorrectAnswer = canShowAnswerAfterSubmission(procedure, isAfterEndTime);
+                fillDataCollectionRemark(detail, dataCollection, canShowCorrectAnswer);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
-                detail.setTolerance(dataCollection.getTolerance());
+                detail.setTolerance(Long.valueOf(2L).equals(dataCollection.getType())
+                        ? dataCollection.getTolerance() : null);
 
                 // 查询附件信息
                 LambdaQueryWrapper<StudentProcedureAttachment> attachmentWrapper = new LambdaQueryWrapper<>();
@@ -528,9 +530,12 @@ public class ClassStudentProcedureQueryService {
                     }
 
                     // 根据答案展示时机配置决定是否返回正确答案
-                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)
-                            && dataCollection.getCorrectAnswer() != null) {
-                        detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
+                    if (canShowCorrectAnswer) {
+                        Map<String, com.example.demo.pojo.dto.mapvo.AnswerRange> correctAnswer =
+                                dataCollection.resolveCorrectAnswerRanges();
+                        if (!correctAnswer.isEmpty()) {
+                            detail.setCorrectAnswer(correctAnswer);
+                        }
                     }
                 }
 
@@ -553,7 +558,7 @@ public class ClassStudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                fillDataCollectionRemark(detail, dataCollection);
+                fillDataCollectionRemark(detail, dataCollection, false);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
                 return detail;
@@ -911,10 +916,11 @@ public class ClassStudentProcedureQueryService {
 
     private void fillDataCollectionRemark(
             StudentProcedureDetailWithAnswerResponse.DataCollectionDetail detail,
-            DataCollection dataCollection) {
+            DataCollection dataCollection,
+            boolean includeCorrectAnswer) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(includeCorrectAnswer));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);

--- a/src/main/java/com/example/demo/service/StudentExperimentService.java
+++ b/src/main/java/com/example/demo/service/StudentExperimentService.java
@@ -393,7 +393,7 @@ public class StudentExperimentService {
     private void fillDataCollectionRemark(StudentProcedureDetailResponse response, DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            response.setFillBlankRemark(dataCollection.resolveFillBlankRemark(false));
             response.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             response.setFillBlankRemark(null);

--- a/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureCompletionService.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.example.demo.exception.BusinessException;
 import com.example.demo.mapper.*;
+import com.example.demo.pojo.dto.mapvo.DataField;
 import com.example.demo.pojo.entity.*;
 import com.example.demo.pojo.request.student.CompleteTimedQuizProcedureRequest;
 import com.example.demo.util.AnswerMapJSONUntil;
@@ -390,28 +391,18 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
                 return AutoGradeExecutionResult.skipped("当前步骤不支持机器批改");
             }
 
-            if (dataCollection.getCorrectAnswer() == null || dataCollection.getCorrectAnswer().trim().isEmpty()) {
-                return AutoGradeExecutionResult.skipped("未配置正确答案");
-            }
-
             // 2. 解析正确答案和误差配置
-            com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
-            java.util.Map<String, String> correctAnswers = objectMapper.readValue(
-                    dataCollection.getCorrectAnswer(),
-                    new com.fasterxml.jackson.core.type.TypeReference<java.util.Map<String, String>>() {}
-            );
+            java.util.Map<String, String> correctAnswers = dataCollection.parseCorrectAnswerMap();
 
             if (correctAnswers == null || correctAnswers.isEmpty()) {
-                return AutoGradeExecutionResult.skipped("正确答案为空");
+                return AutoGradeExecutionResult.skipped("未配置正确答案或正确答案为空");
             }
 
-            // 解析字段级/单元格级/列级误差配置
-            Map<String, Double> fieldTolerances = Map.of();
+            // 解析表格单元格级/列级误差配置
             Map<String, Double> cellTolerances = Map.of();
             Map<String, Double> columnTolerances = Map.of();
             if (dataCollection.getRemark() != null && !dataCollection.getRemark().isEmpty()) {
                 // 从remark字段的JSON中解析误差配置
-                fieldTolerances = DataCollectionDataUtil.parseFieldTolerancesFromJson(dataCollection.getRemark());
                 cellTolerances = DataCollectionDataUtil.parseCellTolerancesFromJson(dataCollection.getRemark());
                 columnTolerances = DataCollectionDataUtil.parseColumnTolerancesFromJson(dataCollection.getRemark());
             }
@@ -421,21 +412,23 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
             int correctCount = 0;
             Double stepTolerance = dataCollection.getTolerance();
 
-            // 判断填空类型答案
-            if (fillBlankAnswers != null && !fillBlankAnswers.isEmpty()) {
+            // 仅填空类型解释填空答案和 RANGE| 内部编码
+            if (Long.valueOf(1L).equals(dataCollection.getType())
+                    && fillBlankAnswers != null
+                    && !fillBlankAnswers.isEmpty()) {
                 for (java.util.Map.Entry<String, String> entry : correctAnswers.entrySet()) {
                     String fieldName = entry.getKey();
                     String studentAnswer = fillBlankAnswers.get(fieldName);
-                    // 优先使用字段级误差，没有则使用步骤级误差
-                    Double fieldTolerance = fieldTolerances.getOrDefault(fieldName, stepTolerance);
-                    if (isAnswerCorrect(studentAnswer, entry.getValue(), fieldTolerance)) {
+                    if (isAnswerCorrect(studentAnswer, entry.getValue(), null, true)) {
                         correctCount++;
                     }
                 }
             }
 
-            // 判断表格类型答案
-            if (tableCellAnswers != null && !tableCellAnswers.isEmpty()) {
+            // 仅表格类型使用表格答案和原有误差逻辑
+            if (Long.valueOf(2L).equals(dataCollection.getType())
+                    && tableCellAnswers != null
+                    && !tableCellAnswers.isEmpty()) {
                 for (java.util.Map.Entry<String, String> entry : correctAnswers.entrySet()) {
                     String positionKey = entry.getKey(); // 格式: "rowIndex-columnIndex"，如 "0-0"
                     String studentAnswer = tableCellAnswers.get(positionKey);
@@ -451,7 +444,7 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
                         }
                     }
 
-                    if (isAnswerCorrect(studentAnswer, entry.getValue(), finalTolerance)) {
+                    if (isAnswerCorrect(studentAnswer, entry.getValue(), finalTolerance, false)) {
                         correctCount++;
                     }
                 }
@@ -491,11 +484,20 @@ public class StudentProcedureCompletionService extends ServiceImpl<StudentProced
      * @param studentAnswer 学生答案
      * @param correctAnswer 正确答案
      * @param tolerance     误差百分比（单位：%）
+     * @param allowRangeEncoding 是否按填空范围解释内部编码
      * @return 是否正确
      */
-    private boolean isAnswerCorrect(String studentAnswer, String correctAnswer, Double tolerance) {
+    private boolean isAnswerCorrect(
+            String studentAnswer,
+            String correctAnswer,
+            Double tolerance,
+            boolean allowRangeEncoding) {
         if (studentAnswer == null || correctAnswer == null) {
             return false;
+        }
+
+        if (allowRangeEncoding) {
+            return DataField.isFillBlankAnswerCorrect(studentAnswer, correctAnswer);
         }
 
         // 尝试按数值比较

--- a/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/StudentProcedureQueryService.java
@@ -310,10 +310,12 @@ public class StudentProcedureQueryService {
                     new StudentProcedureDetailWithAnswerResponse.DataCollectionDetail();
                 detail.setId(dataCollection.getId());
                 detail.setType(dataCollection.getType() != null ? dataCollection.getType().intValue() : null);
-                fillDataCollectionRemark(detail, dataCollection);
+                boolean canShowCorrectAnswer = canShowAnswerAfterSubmission(procedure, isAfterEndTime);
+                fillDataCollectionRemark(detail, dataCollection, canShowCorrectAnswer);
                 detail.setNeedPhoto(dataCollection.getNeedPhoto());
                 detail.setNeedDoc(dataCollection.getNeedDoc());
-                detail.setTolerance(dataCollection.getTolerance());
+                detail.setTolerance(Long.valueOf(2L).equals(dataCollection.getType())
+                        ? dataCollection.getTolerance() : null);
 
                 // 查询附件信息
                 LambdaQueryWrapper<StudentProcedureAttachment> attachmentWrapper = new LambdaQueryWrapper<>();
@@ -373,9 +375,12 @@ public class StudentProcedureQueryService {
                     }
 
                     // 根据答案展示时机配置决定是否返回正确答案
-                    if (canShowAnswerAfterSubmission(procedure, isAfterEndTime)
-                            && dataCollection.getCorrectAnswer() != null) {
-                        detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
+                    if (canShowCorrectAnswer) {
+                        Map<String, com.example.demo.pojo.dto.mapvo.AnswerRange> correctAnswer =
+                                dataCollection.resolveCorrectAnswerRanges();
+                        if (!correctAnswer.isEmpty()) {
+                            detail.setCorrectAnswer(correctAnswer);
+                        }
                     }
                 }
 
@@ -795,10 +800,11 @@ public class StudentProcedureQueryService {
 
     private void fillDataCollectionRemark(
             StudentProcedureDetailWithAnswerResponse.DataCollectionDetail detail,
-            DataCollection dataCollection) {
+            DataCollection dataCollection,
+            boolean includeCorrectAnswer) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(includeCorrectAnswer));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);
@@ -814,7 +820,7 @@ public class StudentProcedureQueryService {
             DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(false));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);

--- a/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureCreationService.java
@@ -176,17 +176,16 @@ public class TeacherProcedureCreationService {
         experimentalProcedureService.save(procedure);
         log.info("数据收集步骤创建成功，步骤ID: {}", procedure.getId());
 
-        // 2. 构建数据描述和正确答案JSON（包含误差配置）
-        Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
-        Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-
+        // 2. 按数据类型构建数据描述和正确答案 JSON
         String remark;
         String correctAnswer;
         if (request.getDataType() == 1) {
+            Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
                     request.getDataFields());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
+            Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                     request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
                     request.getTableColumnTolerances());
@@ -203,7 +202,7 @@ public class TeacherProcedureCreationService {
         dataCollection.setType(request.getDataType().longValue());
         dataCollection.setRemark(remark);
         dataCollection.setCorrectAnswer(correctAnswer);
-        dataCollection.setTolerance(request.getTolerance());
+        dataCollection.setTolerance(request.getDataType() == 2 ? request.getTolerance() : null);
         dataCollection.setNeedPhoto(request.getNeedPhoto() != null ? request.getNeedPhoto() : false);
         dataCollection.setNeedDoc(request.getNeedDoc() != null ? request.getNeedDoc() : false);
 
@@ -424,17 +423,16 @@ public class TeacherProcedureCreationService {
             if (dataCollection != null) {
                 dataCollection.setType(request.getDataType().longValue());
 
-                // 构建数据描述和正确答案JSON（包含误差配置）
-                Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
-                Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-
+                // 按数据类型构建数据描述和正确答案 JSON
                 String remark;
                 String correctAnswer;
                 if (request.getDataType() == 1) {
+                    Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
                     remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
                             request.getDataFields());
                     correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
                 } else if (request.getDataType() == 2) {
+                    Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
                     remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                             request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
                             request.getTableColumnTolerances());
@@ -447,7 +445,7 @@ public class TeacherProcedureCreationService {
 
                 dataCollection.setRemark(remark);
                 dataCollection.setCorrectAnswer(correctAnswer);
-                dataCollection.setTolerance(request.getTolerance());
+                dataCollection.setTolerance(request.getDataType() == 2 ? request.getTolerance() : null);
                 dataCollection.setNeedPhoto(request.getNeedPhoto() != null ? request.getNeedPhoto() : dataCollection.getNeedPhoto());
                 dataCollection.setNeedDoc(request.getNeedDoc() != null ? request.getNeedDoc() : dataCollection.getNeedDoc());
                 dataCollectionMapper.updateById(dataCollection);
@@ -695,17 +693,16 @@ public class TeacherProcedureCreationService {
         experimentalProcedureService.save(procedure);
         log.info("数据收集步骤插入成功，步骤ID: {}", procedure.getId());
 
-        // 构建数据描述和正确答案JSON（包含误差配置）
-        Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
-        Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
-
+        // 按数据类型构建数据描述和正确答案 JSON
         String remark;
         String correctAnswer;
         if (request.getDataType() == 1) {
+            Map<String, String> dataFieldsMap = DataField.toMap(request.getDataFields());
             remark = com.example.demo.util.DataCollectionDataUtil.convertFillBlanksToJson(
                     request.getDataFields());
             correctAnswer = com.example.demo.util.DataCollectionDataUtil.convertCorrectAnswerToJson(dataFieldsMap);
         } else if (request.getDataType() == 2) {
+            Map<String, String> tableCellAnswersMap = TableCellAnswer.toMap(request.getTableCellAnswers());
             remark = com.example.demo.util.DataCollectionDataUtil.convertTableToJson(
                     request.getTableRowHeaders(), request.getTableColumnHeaders(), request.getTableCellAnswers(),
                     request.getTableColumnTolerances());
@@ -722,7 +719,7 @@ public class TeacherProcedureCreationService {
         dataCollection.setType(request.getDataType().longValue());
         dataCollection.setRemark(remark);
         dataCollection.setCorrectAnswer(correctAnswer);
-        dataCollection.setTolerance(request.getTolerance());
+        dataCollection.setTolerance(request.getDataType() == 2 ? request.getTolerance() : null);
         dataCollection.setNeedPhoto(request.getNeedPhoto() != null ? request.getNeedPhoto() : false);
         dataCollection.setNeedDoc(request.getNeedDoc() != null ? request.getNeedDoc() : false);
 

--- a/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherProcedureQueryService.java
@@ -195,7 +195,8 @@ public class TeacherProcedureQueryService {
             fillDataCollectionRemark(response, dataCollection);
             response.setDataNeedPhoto(dataCollection.getNeedPhoto());
             response.setDataNeedDoc(dataCollection.getNeedDoc());
-            response.setTolerance(dataCollection.getTolerance());
+            response.setTolerance(Long.valueOf(2L).equals(dataCollection.getType())
+                    ? dataCollection.getTolerance() : null);
         }
     }
 
@@ -555,14 +556,15 @@ public class TeacherProcedureQueryService {
             fillDataCollectionRemark(response, dataCollection);
             response.setDataNeedPhoto(dataCollection.getNeedPhoto());
             response.setDataNeedDoc(dataCollection.getNeedDoc());
-            response.setTolerance(dataCollection.getTolerance());
+            response.setTolerance(Long.valueOf(2L).equals(dataCollection.getType())
+                    ? dataCollection.getTolerance() : null);
         }
     }
 
     private void fillDataCollectionRemark(TeacherProcedureDetailResponse response, DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            response.setFillBlankRemark(dataCollection.resolveFillBlankRemark(true));
             response.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             response.setFillBlankRemark(null);
@@ -576,7 +578,7 @@ public class TeacherProcedureQueryService {
     private void fillDataCollectionRemark(TeacherDataCollectionProcedureDetailResponse response, DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            response.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            response.setFillBlankRemark(dataCollection.resolveFillBlankRemark(true));
             response.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             response.setFillBlankRemark(null);

--- a/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
+++ b/src/main/java/com/example/demo/service/TeacherStudentProcedureQueryService.java
@@ -1019,8 +1019,10 @@ public class TeacherStudentProcedureQueryService {
                 }
 
                 // 教师始终可以查看正确答案
-                if (dataCollection.getCorrectAnswer() != null) {
-                    detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
+                Map<String, com.example.demo.pojo.dto.mapvo.AnswerRange> correctAnswer =
+                        dataCollection.resolveCorrectAnswerRanges();
+                if (!correctAnswer.isEmpty()) {
+                    detail.setCorrectAnswer(correctAnswer);
                 }
 
                 response.setDataCollectionDetail(detail);
@@ -1233,7 +1235,7 @@ public class TeacherStudentProcedureQueryService {
             DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(true));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);
@@ -1249,7 +1251,7 @@ public class TeacherStudentProcedureQueryService {
             DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(true));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);
@@ -1265,7 +1267,7 @@ public class TeacherStudentProcedureQueryService {
             DataCollection dataCollection) {
         Integer type = dataCollection.getType() != null ? dataCollection.getType().intValue() : null;
         if (Integer.valueOf(1).equals(type)) {
-            detail.setFillBlankRemark(DataCollectionDataUtil.parseFillBlankRemark(dataCollection.getRemark(), dataCollection.getCorrectAnswer()));
+            detail.setFillBlankRemark(dataCollection.resolveFillBlankRemark(true));
             detail.setTableRemark(null);
         } else if (Integer.valueOf(2).equals(type)) {
             detail.setFillBlankRemark(null);
@@ -1488,8 +1490,10 @@ public class TeacherStudentProcedureQueryService {
                 }
 
                 // 正确答案
-                if (dataCollection.getCorrectAnswer() != null) {
-                    detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
+                Map<String, com.example.demo.pojo.dto.mapvo.AnswerRange> correctAnswer =
+                        dataCollection.resolveCorrectAnswerRanges();
+                if (!correctAnswer.isEmpty()) {
+                    detail.setCorrectAnswer(correctAnswer);
                 }
 
                 response.setDataCollectionDetail(detail);
@@ -1538,8 +1542,10 @@ public class TeacherStudentProcedureQueryService {
                 detail.setNeedDoc(dataCollection.getNeedDoc());
 
                 // 正确答案
-                if (dataCollection.getCorrectAnswer() != null) {
-                    detail.setCorrectAnswer(dataCollection.getCorrectAnswer());
+                Map<String, com.example.demo.pojo.dto.mapvo.AnswerRange> correctAnswer =
+                        dataCollection.resolveCorrectAnswerRanges();
+                if (!correctAnswer.isEmpty()) {
+                    detail.setCorrectAnswer(correctAnswer);
                 }
 
                 response.setDataCollectionDetail(detail);

--- a/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
+++ b/src/main/java/com/example/demo/util/DataCollectionDataUtil.java
@@ -6,7 +6,6 @@ import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
 import com.example.demo.pojo.dto.remark.TableRemarkDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +17,7 @@ import java.util.Map;
  * 用于将结构化的填空和表格数据转换为JSON格式存储到 remark 字段
  *
  * remark JSON 格式（按数据类型区分）：
- * - 填空类型（type=1）：{"fillBlanks":[{"fieldName":"Uab","value":"","tolerance":5.0}]}
+ * - 填空类型（type=1）：{"fillBlanks":[{"fieldName":"Uab"}]}
  * - 表格类型（type=2）：{"tableRowHeaders":["A","B"],"tableColumnHeaders":["1","2"],
  *   "tableCellAnswers":[{"rowIndex":0,"columnIndex":0,"value":"3.5","tolerance":5.0}],
  *   "columnTolerances":[{"columnIndex":0,"tolerance":3.0}]}
@@ -34,13 +33,20 @@ public class DataCollectionDataUtil {
     /**
      * 将填空类型数据转换为JSON
      *
-     * @param dataFields 填空数据列表（fieldName + value + tolerance）
+     * @param dataFields 填空数据列表（fieldName + min + max）
      * @return JSON字符串
      */
     public static String convertFillBlanksToJson(List<DataField> dataFields) {
         try {
+            List<DataField> structureFields = dataFields == null ? null : dataFields.stream()
+                    .map(field -> {
+                        DataField structureField = new DataField();
+                        structureField.setFieldName(field.getFieldName());
+                        return structureField;
+                    })
+                    .toList();
             FillBlankRemarkDTO dto = FillBlankRemarkDTO.builder()
-                    .fillBlanks(dataFields)
+                    .fillBlanks(structureFields)
                     .build();
             return objectMapper.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
@@ -107,25 +113,32 @@ public class DataCollectionDataUtil {
     }
 
     /**
-     * 从 remark JSON 和 correctAnswer JSON 中解析填空类型 DTO
-     * remark 提供字段结构与误差，correctAnswer 提供字段值
+     * 从 remark JSON 和已统一解析的正确答案 Map 中生成填空类型 DTO。
+     * remark 提供字段结构，正确答案是否合并由调用方的展示策略决定。
      *
      * @param remarkJson remark JSON字符串
-     * @param correctAnswerJson correctAnswer JSON字符串
+     * @param correctAnswerMap 已由 DataCollection 统一解析的正确答案
+     * @param includeCorrectAnswer 是否返回正确答案范围
      * @return 填空类型 DTO，解析失败时尽量返回可用结构
      */
-    public static FillBlankRemarkDTO parseFillBlankRemark(String remarkJson, String correctAnswerJson) {
+    public static FillBlankRemarkDTO parseFillBlankRemark(
+            String remarkJson,
+            Map<String, String> correctAnswerMap,
+            boolean includeCorrectAnswer) {
         FillBlankRemarkDTO dto = parseFillBlankRemark(remarkJson);
-        Map<String, String> correctAnswerMap = parseCorrectAnswer(correctAnswerJson);
 
         if (dto != null && dto.getFillBlanks() != null && !dto.getFillBlanks().isEmpty()) {
-            if (!correctAnswerMap.isEmpty()) {
-                dto.getFillBlanks().forEach(field -> field.setValue(correctAnswerMap.get(field.getFieldName())));
-            }
+            dto.getFillBlanks().forEach(field -> {
+                if (!includeCorrectAnswer) {
+                    field.applyCorrectAnswerValue(null);
+                } else if (correctAnswerMap.containsKey(field.getFieldName())) {
+                    field.applyCorrectAnswerValue(correctAnswerMap.get(field.getFieldName()));
+                }
+            });
             return dto;
         }
 
-        if (correctAnswerMap.isEmpty()) {
+        if (!includeCorrectAnswer || correctAnswerMap.isEmpty()) {
             return dto;
         }
 
@@ -147,20 +160,6 @@ public class DataCollectionDataUtil {
             log.error("解析表格类型 remark 失败", e);
             return null;
         }
-    }
-
-    /**
-     * 从JSON中解析字段级误差映射
-     *
-     * @param json 数据收集JSON字符串
-     * @return 字段级误差映射
-     */
-    public static Map<String, Double> parseFieldTolerancesFromJson(String json) {
-        FillBlankRemarkDTO dto = parseFillBlankRemark(json);
-        if (dto == null || dto.getFillBlanks() == null) {
-            return Map.of();
-        }
-        return DataField.toToleranceMap(dto.getFillBlanks());
     }
 
     /**
@@ -191,16 +190,4 @@ public class DataCollectionDataUtil {
         return ColumnTolerance.toMap(dto.getColumnTolerances());
     }
 
-    private static Map<String, String> parseCorrectAnswer(String correctAnswerJson) {
-        if (correctAnswerJson == null || correctAnswerJson.trim().isEmpty()) {
-            return Map.of();
-        }
-
-        try {
-            return objectMapper.readValue(correctAnswerJson, new TypeReference<Map<String, String>>() {});
-        } catch (JsonProcessingException e) {
-            log.error("解析填空类型 correctAnswer 失败", e);
-            return Map.of();
-        }
-    }
 }

--- a/src/test/java/com/example/demo/pojo/entity/DataCollectionTest.java
+++ b/src/test/java/com/example/demo/pojo/entity/DataCollectionTest.java
@@ -1,0 +1,173 @@
+package com.example.demo.pojo.entity;
+
+import com.example.demo.pojo.dto.mapvo.DataField;
+import com.example.demo.pojo.dto.remark.FillBlankRemarkDTO;
+import com.example.demo.util.DataCollectionDataUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataCollectionTest {
+
+    @Test
+    void parseCorrectAnswerMapParsesStoredJson() {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setCorrectAnswer("{\"Uab\":\"220\",\"I1\":\"0.5\"}");
+
+        Map<String, String> result = dataCollection.parseCorrectAnswerMap();
+
+        assertEquals(Map.of("Uab", "220", "I1", "0.5"), result);
+    }
+
+    @Test
+    void parseCorrectAnswerMapRejectsInvalidJson() {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setCorrectAnswer("not-json");
+
+        assertThrows(IllegalArgumentException.class, dataCollection::parseCorrectAnswerMap);
+    }
+
+    @Test
+    void resolveFillBlankRemarkMergesCorrectAnswerValues() throws Exception {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setRemark("{\"fillBlanks\":[{\"fieldName\":\"Uab\",\"value\":\"\"}]}");
+        dataCollection.setCorrectAnswer("{\"Uab\":\"220\"}");
+
+        FillBlankRemarkDTO result = dataCollection.resolveFillBlankRemark(true);
+
+        assertEquals("220", result.getFillBlanks().get(0).getMin());
+        assertEquals("220", result.getFillBlanks().get(0).getMax());
+
+        String responseJson = new ObjectMapper().writeValueAsString(result);
+        assertTrue(responseJson.contains("\"min\":\"220\""));
+        assertTrue(responseJson.contains("\"max\":\"220\""));
+        assertFalse(responseJson.contains("\"value\""));
+    }
+
+    @Test
+    void resolveFillBlankRemarkExpandsRangeAnswer() throws Exception {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setRemark("{\"fillBlanks\":[{\"fieldName\":\"Uab\",\"value\":\"\"}]}");
+        dataCollection.setCorrectAnswer("{\"Uab\":\"RANGE|210.0|230.0\"}");
+
+        FillBlankRemarkDTO result = dataCollection.resolveFillBlankRemark(true);
+
+        assertEquals("210.0", result.getFillBlanks().get(0).getMin());
+        assertEquals("230.0", result.getFillBlanks().get(0).getMax());
+
+        String responseJson = new ObjectMapper().writeValueAsString(result);
+        assertTrue(responseJson.contains("\"min\":\"210.0\""));
+        assertTrue(responseJson.contains("\"max\":\"230.0\""));
+        assertFalse(responseJson.contains("\"value\""));
+    }
+
+    @Test
+    void rangeAnswerIsStoredInCorrectAnswerButNotRemark() {
+        DataField field = new DataField();
+        field.setFieldName("Uab");
+        field.setMin("210.0");
+        field.setMax("230.0");
+
+        assertEquals("RANGE|210.0|230.0", DataField.toMap(java.util.List.of(field)).get("Uab"));
+
+        String remarkJson = DataCollectionDataUtil.convertFillBlanksToJson(java.util.List.of(field));
+        assertFalse(remarkJson.contains("\"min\""));
+        assertFalse(remarkJson.contains("\"max\""));
+    }
+
+    @Test
+    void rangeAnswerUsesInclusiveBoundsWithoutTolerance() {
+        String range = "RANGE|210.0|230.0";
+
+        assertTrue(DataField.isAnswerWithinRange("210.0", range));
+        assertTrue(DataField.isAnswerWithinRange("220", range));
+        assertTrue(DataField.isAnswerWithinRange("230.0", range));
+        assertFalse(DataField.isAnswerWithinRange("209.99", range));
+        assertFalse(DataField.isAnswerWithinRange("230.01", range));
+    }
+
+    @Test
+    void resolveCorrectAnswerRangesReturnsStructuredMinAndMax() throws Exception {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setCorrectAnswer("{\"0-0\":\"RANGE|3.3|3.7\",\"0-1\":\"60\"}");
+
+        assertEquals("3.3", dataCollection.resolveCorrectAnswerRanges().get("0-0").getMin());
+        assertEquals("3.7", dataCollection.resolveCorrectAnswerRanges().get("0-0").getMax());
+        assertEquals("60", dataCollection.resolveCorrectAnswerRanges().get("0-1").getMin());
+        assertEquals("60", dataCollection.resolveCorrectAnswerRanges().get("0-1").getMax());
+
+        String responseJson = new ObjectMapper()
+                .writeValueAsString(dataCollection.resolveCorrectAnswerRanges());
+        assertTrue(responseJson.contains("\"0-0\":{\"min\":\"3.3\",\"max\":\"3.7\"}"));
+        assertFalse(responseJson.contains("RANGE|"));
+    }
+
+    @Test
+    void entitySerializationDoesNotExposeStoredCorrectAnswer() throws Exception {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setCorrectAnswer("{\"Uab\":\"RANGE|210|230\"}");
+
+        String json = new ObjectMapper().writeValueAsString(dataCollection);
+
+        assertFalse(json.contains("correctAnswer"));
+        assertFalse(json.contains("RANGE|"));
+    }
+
+    @Test
+    void malformedInternalRangeIsRejectedInsteadOfExposed() {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setCorrectAnswer("{\"Uab\":\"RANGE|210\"}");
+
+        assertThrows(IllegalArgumentException.class, dataCollection::resolveCorrectAnswerRanges);
+    }
+
+    @Test
+    void hiddenAnswerRemarkContainsStructureOnlyEvenForLegacyValue() throws Exception {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setRemark("{\"fillBlanks\":[{\"fieldName\":\"Uab\",\"value\":\"220\"}]}");
+        dataCollection.setCorrectAnswer("{\"Uab\":\"RANGE|210|230\"}");
+
+        String responseJson = new ObjectMapper()
+                .writeValueAsString(dataCollection.resolveFillBlankRemark(false));
+
+        assertTrue(responseJson.contains("\"fieldName\":\"Uab\""));
+        assertFalse(responseJson.contains("\"value\""));
+        assertFalse(responseJson.contains("\"min\""));
+        assertFalse(responseJson.contains("\"max\""));
+        assertFalse(responseJson.contains("RANGE|"));
+    }
+
+    @Test
+    void invalidNumericOrReversedInternalRangesAreRejected() {
+        DataCollection invalidNumber = new DataCollection();
+        invalidNumber.setCorrectAnswer("{\"Uab\":\"RANGE|abc|230\"}");
+        DataCollection reversed = new DataCollection();
+        reversed.setCorrectAnswer("{\"Uab\":\"RANGE|230|210\"}");
+
+        assertThrows(IllegalArgumentException.class, invalidNumber::resolveCorrectAnswerRanges);
+        assertThrows(IllegalArgumentException.class, reversed::resolveCorrectAnswerRanges);
+    }
+
+    @Test
+    void legacyExactAnswerUsesTrueMinEqualsMaxComparison() {
+        assertTrue(DataField.isFillBlankAnswerCorrect("220.0", "220"));
+        assertFalse(DataField.isFillBlankAnswerCorrect("220.00009", "220"));
+        assertTrue(DataField.isFillBlankAnswerCorrect("OK", "ok"));
+    }
+
+    @Test
+    void tableAnswerWithRangePrefixRemainsAnExactString() {
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setType(2L);
+        dataCollection.setCorrectAnswer("{\"0-0\":\"RANGE|3|5\"}");
+
+        assertEquals("RANGE|3|5", dataCollection.resolveCorrectAnswerRanges().get("0-0").getMin());
+        assertEquals("RANGE|3|5", dataCollection.resolveCorrectAnswerRanges().get("0-0").getMax());
+    }
+}

--- a/src/test/java/com/example/demo/service/StudentProcedureCompletionServiceTest.java
+++ b/src/test/java/com/example/demo/service/StudentProcedureCompletionServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.demo.service;
+
+import com.example.demo.mapper.ClassExperimentClassRelationMapper;
+import com.example.demo.mapper.ClassExperimentMapper;
+import com.example.demo.mapper.DataCollectionMapper;
+import com.example.demo.mapper.ProcedureTopicMapMapper;
+import com.example.demo.mapper.ProcedureTopicMapper;
+import com.example.demo.mapper.TimedQuizProcedureMapper;
+import com.example.demo.mapper.TopicMapper;
+import com.example.demo.pojo.entity.DataCollection;
+import com.example.demo.pojo.entity.ExperimentalProcedure;
+import com.example.demo.pojo.entity.StudentExperimentalProcedure;
+import com.example.demo.util.AnswerMapJSONUntil;
+import com.example.demo.util.TimedQuizKeyGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudentProcedureCompletionServiceTest {
+
+    @Mock
+    private StudentExperimentalProcedureService studentExperimentalProcedureService;
+    @Mock
+    private ExperimentalProcedureService experimentalProcedureService;
+    @Mock
+    private ProcedureTopicMapper procedureTopicMapper;
+    @Mock
+    private ProcedureTopicMapMapper procedureTopicMapMapper;
+    @Mock
+    private DataCollectionMapper dataCollectionMapper;
+    @Mock
+    private TimedQuizProcedureMapper timedQuizProcedureMapper;
+    @Mock
+    private TopicMapper topicMapper;
+    @Mock
+    private TimedQuizKeyGenerator timedQuizKeyGenerator;
+    @Mock
+    private ClassExperimentMapper classExperimentMapper;
+    @Mock
+    private ClassExperimentClassRelationMapper classExperimentClassRelationMapper;
+
+    @InjectMocks
+    private StudentProcedureCompletionService service;
+
+    @Test
+    void tableGradingIgnoresInjectedFillBlankAnswersAndRangeEncoding() {
+        StudentExperimentalProcedure submission = new StudentExperimentalProcedure();
+        submission.setId(100L);
+        submission.setExperimentalProcedureId(10L);
+        submission.setIsGraded(0);
+        submission.setAnswer(AnswerMapJSONUntil.toDataCollectionJson(
+                Map.of("0-0", "4"),
+                Map.of("0-0", "4")));
+
+        ExperimentalProcedure procedure = new ExperimentalProcedure();
+        procedure.setId(10L);
+        procedure.setType(2);
+        procedure.setIsDeleted(false);
+
+        DataCollection dataCollection = new DataCollection();
+        dataCollection.setType(2L);
+        dataCollection.setRemark("{}");
+        dataCollection.setCorrectAnswer("{\"0-0\":\"RANGE|3|5\"}");
+
+        when(studentExperimentalProcedureService.getById(100L)).thenReturn(submission);
+        when(studentExperimentalProcedureService.updateById(any())).thenReturn(true);
+        when(experimentalProcedureService.getById(10L)).thenReturn(procedure);
+        when(dataCollectionMapper.selectOne(any())).thenReturn(dataCollection);
+
+        StudentProcedureCompletionService.AutoGradeExecutionResult result =
+                service.autoGradeExistingDataCollectionSubmission(100L);
+
+        assertTrue(result.isSuccess());
+        assertEquals(0, submission.getScore().compareTo(new BigDecimal("0.00")));
+    }
+}

--- a/src/test/java/com/example/demo/service/TeacherProcedureCreationServiceTest.java
+++ b/src/test/java/com/example/demo/service/TeacherProcedureCreationServiceTest.java
@@ -6,7 +6,10 @@ import com.example.demo.mapper.ProcedureTopicMapMapper;
 import com.example.demo.mapper.ProcedureTopicMapper;
 import com.example.demo.mapper.TimedQuizProcedureMapper;
 import com.example.demo.mapper.TopicMapper;
+import com.example.demo.pojo.dto.mapvo.DataField;
+import com.example.demo.pojo.dto.mapvo.TableCellAnswer;
 import com.example.demo.pojo.entity.ExperimentalProcedure;
+import com.example.demo.pojo.request.teacher.CreateDataCollectionProcedureRequest;
 import com.example.demo.pojo.request.teacher.InsertTopicProcedureRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,6 +70,28 @@ class TeacherProcedureCreationServiceTest {
                 () -> teacherProcedureCreationService.insertTopicProcedure(request));
 
         assertEquals("随机抽题必须携带标签", ex.getMessage());
+    }
+
+    @Test
+    void tableCreationIgnoresResidualInvalidFillBlankFields() {
+        CreateDataCollectionProcedureRequest request = new CreateDataCollectionProcedureRequest();
+        request.setExperimentId(1L);
+        request.setDataType(2);
+        request.setDurationMinutes(10);
+        request.setTableRowHeaders(List.of("row"));
+        request.setTableColumnHeaders(List.of("column"));
+
+        TableCellAnswer tableAnswer = new TableCellAnswer();
+        tableAnswer.setRowIndex(0);
+        tableAnswer.setColumnIndex(0);
+        tableAnswer.setValue("3.5");
+        request.setTableCellAnswers(List.of(tableAnswer));
+
+        DataField residualFillField = new DataField();
+        residualFillField.setFieldName("unused");
+        request.setDataFields(List.of(residualFillField));
+
+        assertDoesNotThrow(() -> teacherProcedureCreationService.createDataCollectionProcedure(request));
     }
 
     private InsertTopicProcedureRequest buildBaseInsertRequest() {


### PR DESCRIPTION
## 修改内容
- 数据收集填空正确答案改为 min/max 范围结构，去除 value 和填空误差
- 正确答案仍存储在 data_collection.correct_answer，并由 DataCollection 的统一方法解析
- 旧精确答案在服务端转换为 min=max，旧 value 仅用于兼容反序列化
- 接口不返回原始 correct_answer JSON、RANGE| 内部编码或旧 value
- 学生端严格遵守答案展示时机，教师端返回结构化范围
- 填空按包含边界的范围判分，表格原误差逻辑保持不变

## 审查修复
- 修复学生未到答案展示时间时通过 fillBlankRemark 泄漏范围
- 修复旧精确值判分与 min=max 契约不一致
- 限制 RANGE| 只用于填空类型，避免影响表格答案
- 移除正确答案 JSON 的独立解析旁路
- 拒绝非数字、倒置或损坏的内部范围
- 非填空请求不再校验残留 dataFields

## 验证
- mvnw.cmd -Dtest=DataCollectionTest,TeacherProcedureCreationServiceTest,TopicTagMatchServiceTest test
- 22 tests passed
- git diff --check passed